### PR TITLE
next try

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,5 @@
 
 source 'https://rubygems.org'
 
-gem 'macaddr'
 gem 'tty-markdown'
 gem 'commander'

--- a/bin/hunter
+++ b/bin/hunter
@@ -63,6 +63,7 @@ $LOAD_PATH.unshift(File.join(FlightHunter::Config.root_dir, 'lib'))
 require 'flight_hunter/client/send'
 require 'flight_hunter/client/modify_ip'
 require 'flight_hunter/client/modify_port'
+require 'collector'
 require 'flight_hunter/server/hunt'
 require 'flight_hunter/server/list'
 require 'flight_hunter/server/manual'
@@ -155,9 +156,10 @@ module FlightHunter
     command 'show' do |c|
       c.syntax = "#{ program(:name) } NAME"
       c.summary = 'Show the details of a particular entry.'
-      c.action do |args, _|
+      c.option '--plain', 'Plain output (csv)'
+      c.action do |args, options|
         name = args[0]
-        Server::Show.new.show(parsed, name)
+        Server::Show.new.show(parsed, name, options.plain)
       end
     end
 

--- a/bin/hunter
+++ b/bin/hunter
@@ -67,13 +67,13 @@ require 'flight_hunter/server/hunt'
 require 'flight_hunter/server/list'
 require 'flight_hunter/server/manual'
 require 'flight_hunter/server/automatic'
-require 'flight_hunter/server/remove_mac'
+require 'flight_hunter/server/remove_id'
 require 'flight_hunter/server/remove_name'
 require 'flight_hunter/server/modify_port'
-require 'flight_hunter/server/modify_mac'
+require 'flight_hunter/server/modify_id'
 require 'flight_hunter/server/modify_name'
 require 'flight_hunter/server/dump_buffer'
-require 'flight_hunter/server/show_node'
+require 'flight_hunter/server/show'
 
 require 'csv'
 require 'commander'
@@ -101,7 +101,7 @@ module FlightHunter
     end
 
     command 'send' do |c|
-      c.summary = 'Send MAC/hostname plus optional payload to server.'
+      c.summary = 'Push my identity plus optional payload to server.'
       c.option '--file FILE', 'Payload file'
       c.option '--server SERVERIP', 'Override server IP'
       c.option '--port PORT', 'Override server port'
@@ -110,7 +110,7 @@ module FlightHunter
         ipaddr = options.server.to_s.empty? ? Config.data[:ipaddr] : options.server
         port = options.port.to_s.empty? ? Config.data[:clientport] : options.port
         filepath = options.file if options.file
-        Client::Send.new.send_mac(ipaddr,port,filepath,options.spoof)
+        Client::Send.new.send(ipaddr,port,filepath,options.spoof)
       end
     end
 
@@ -152,12 +152,12 @@ module FlightHunter
         Server::ListNodes.new.list_nodes(parsed,options.plain)
       end
     end
-    command 'show-node' do |c|
+    command 'show' do |c|
       c.syntax = "#{ program(:name) } NAME"
-      c.summary = 'Show the details of a particular node.'
+      c.summary = 'Show the details of a particular entry.'
       c.action do |args, _|
         name = args[0]
-        Server::ShowNode.new.show_node(parsed, name)
+        Server::Show.new.show(parsed, name)
       end
     end
 
@@ -177,12 +177,12 @@ module FlightHunter
       end
     end
 
-    command 'remove-mac' do |c|
-      c.syntax = "#{ program(:name) } MAC"
-      c.summary = 'Remove a node from the parsed list by MAC.'
+    command 'remove-id' do |c|
+      c.syntax = "#{ program(:name) } ID"
+      c.summary = 'Remove an entity from the parsed list by id.'
       c.action do |args, _|
-        mac = args
-        Server::RemoveMac.new.remove_mac(parsed,mac)
+        id = args
+        Server::RemoveID.new.remove_id(parsed,id)
       end
     end
 
@@ -190,8 +190,8 @@ module FlightHunter
       c.syntax = "#{ program(:name) } NAME"
       c.summary = 'Remove an node from the parsed list by NAME.'
       c.action do |args, _|
-        hostname = args
-        Server::RemoveName.new.remove_name(parsed,hostname)
+        name = args
+        Server::RemoveName.new.remove_name(parsed,name)
       end
     end
 
@@ -204,12 +204,12 @@ module FlightHunter
       end
     end
 
-    command 'modify-mac' do |c|
-      c.syntax = "#{ program(:name) } OLDMAC NEWMAC"
-      c.summary = 'Modify the MAC of a node in the parsed list.'
+    command 'modify-id' do |c|
+      c.syntax = "#{ program(:name) } OLDID NEWID"
+      c.summary = 'Modify the ID of a node in the parsed list.'
       c.action do |args, _|
-        oldmac, newmac = args
-        Server::ModifyMac.new.modify_mac(parsed, oldmac, newmac)
+        oldid, newid = args
+        Server::ModifyID.new.modify_id(parsed, oldid, newid)
       end
     end
 

--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -1,0 +1,75 @@
+#!/usr/bin/env ruby
+#==============================================================================
+## Copyright (C) 2019-present Alces Flight Ltd.
+##
+## This file is part of Hunter.
+##
+## This program and the accompanying materials are made available under
+## the terms of the Eclipse Public License 2.0 which is available at
+## <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+## terms made available by Alces Flight Ltd - please direct inquiries
+## about licensing to licensing@alces-flight.com.
+##
+## Hunter is distributed in the hope that it will be useful, but
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+## IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+## OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+## PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+## details.
+##
+## You should have received a copy of the Eclipse Public License 2.0
+## along with Hunter. If not, see:
+##
+##  https://opensource.org/licenses/EPL-2.0
+##
+## For more information on Hunter, please visit:
+## https://github.com/openflighthpc/hunter
+##===============================================================================
+#
+
+module BasicCollector
+  def self::collect
+    payload={}
+
+    #pickup possible things we like from the kernel cmdline
+    cmdline = ::File::read('/proc/cmdline').split.map { |a| h=a.split('='); [h.first,h.last] if h.size == 2}.compact.to_h
+
+    payload[:sysuuid] = cmdline['SYSUUID']
+    payload[:bootif] = cmdline['BOOTIF']
+
+    #quick go at network interfaces
+    nets={}
+    begin
+      ::Dir::entries('/sys/class/net').reject! {|x| x =~ /\.|\.\.|lo/i }.sort.each { |net|
+        nets[net] = ::File::read("/sys/class/net/#{net}/address").chomp rescue "unknown"
+      }
+    rescue
+  
+    end
+
+    payload[:nets]=nets.compact
+
+    #and at disks
+    disks={}
+    begin
+      ::Dir::entries('/sys/class/block').reject! {|x| x =~ /\.|\.\./i }.sort.each { |disk|
+        if ::Dir::exist? "/sys/class/block/#{disk}/device"
+          disks[disk]=::File::read("/sys/class/block/#{disk}/size").chomp rescue nil
+        end
+    }
+    rescue
+
+    end
+
+    payload[:disks]=disks.compact
+
+    #finally best we can do somewhat dodgy attempt to pick up BMC info
+    addr=`ipmitool lan print 1 | grep -e "IP Address" | grep -vi "Source"| awk '{ print $4 }'`.chomp rescue nil
+    payload[:bmcip]= addr unless addr.to_s.empty? 
+    mac=`ipmitool lan print 1 | grep 'MAC Address' | awk '{ print $4 }'`.chomp rescue nil
+    payload[:bmcmac]= mac unless mac.to_s.empty?
+
+    payload.compact
+  end
+end
+

--- a/lib/flight_hunter/client/send.rb
+++ b/lib/flight_hunter/client/send.rb
@@ -28,19 +28,18 @@
 # https://github.com/openflighthpc/hunter
 #===============================================================================
 
-require 'macaddr'
 require 'socket'
 
 module FlightHunter
 	module Client
 		class Send
-			def send_mac(ipaddr,port,filename=nil,spoof=nil)
-				mac = Mac.addr
+			def send(ipaddr,port,filename=nil,spoof=nil)
+				hostid = `hostid`.chomp
 				myhostname = spoof.to_s.empty? ? Socket.gethostname : spoof
 				if filename != nil
 					fileContent = File.read(filename)
 				end
-				payload = [mac,myhostname,fileContent].pack('Z*Z*Z*')
+				payload = [hostid,myhostname,fileContent].pack('Z*Z*Z*')
 				begin
 					server = TCPSocket.open(ipaddr,port)
 					server.write(payload)

--- a/lib/flight_hunter/client/send.rb
+++ b/lib/flight_hunter/client/send.rb
@@ -29,15 +29,19 @@
 #===============================================================================
 
 require 'socket'
+require 'yaml'
 
 module FlightHunter
 	module Client
 		class Send
 			def send(ipaddr,port,filename=nil,spoof=nil)
-				hostid = `hostid`.chomp
+				hostid = ::File::read('/proc/cmdline').split.map { |a| h=a.split('='); [h.first,h.last] if h.size == 2}.compact.to_h['SYSUUID'] || `hostid`.chomp rescue `hostid`.chomp
 				myhostname = spoof.to_s.empty? ? Socket.gethostname : spoof
 				if filename != nil
 					fileContent = File.read(filename)
+				else
+					#we don't have a file the payload, so lets stick some yaml there instead
+					fileContent = BasicCollector::collect.to_yaml
 				end
 				payload = [hostid,myhostname,fileContent].pack('Z*Z*Z*')
 				begin

--- a/lib/flight_hunter/server/automatic.rb
+++ b/lib/flight_hunter/server/automatic.rb
@@ -39,7 +39,7 @@ module FlightHunter
 				existing = []
 				to_add = {}
 				start_val = start.dup
-				buffer.each do |mac,vals|
+				buffer.each do |id,vals|
 					if start_val.length < length
 						start_val.prepend("0"* (length-start_val.length))
 					elsif start_val.length > length
@@ -47,9 +47,9 @@ module FlightHunter
 					end
 
 					newname = prefix+start_val
-					if parsed.key?(mac) || hostsearch.search(parsed,newname)			
-						if parsed.key?(mac)			
-							existing.push([mac,parsed[mac]])
+					if parsed.key?(id) || hostsearch.search(parsed,newname)			
+						if parsed.key?(id)			
+							existing.push([id,parsed[id]])
 						end
 						if hostsearch.search(parsed,newname)
 							parsed.each do |key,value|
@@ -61,7 +61,7 @@ module FlightHunter
 						existing.uniq!
 						existing.each { |element| parsed.delete(element[0])}	
 					end
-					to_add[mac] = {"hostname" => newname, "ip" => vals["ip"], "payload" => vals["payload"]}.compact
+					to_add[id] = {"hostname" => newname, "ip" => vals["ip"], "payload" => vals["payload"]}.compact
 					start_val.succ!
 				end
 				if !existing.empty?

--- a/lib/flight_hunter/server/hunt.rb
+++ b/lib/flight_hunter/server/hunt.rb
@@ -50,39 +50,39 @@ module FlightHunter
 				Thread.new do
 					loop do
 						client = server.accept
-						mac,host,fileContent = client.read.unpack("Z*Z*Z*")
+						id,host,fileContent = client.read.unpack("Z*Z*Z*")
 						vals = {"hostname"=> host,"ip" => (client.peeraddr[2] || 'unknown'),"payload" => fileContent}.reject { |k,v| v==''}
 						if !allow_existing
-							if buffer.key?(mac)
-								puts "This MAC address already exists in the unprocessed list. Ignoring..."
+							if buffer.key?(id)
+								puts "This ID already exists in the unprocessed list. Ignoring..."
 							elsif search_hostname.search(buffer,host)
 								puts "This hostname already exists in the unprocessed list. Ignoring..."
-							elsif parsed.key?(mac)
-								puts "This MAC address already exists in the processed list. Ignoring..."
+							elsif parsed.key?(id)
+								puts "This ID already exists in the processed list. Ignoring..."
 							elsif search_hostname.search(parsed,host)
 								puts "This hostname already exists in the processed list. Ignoring..."
 							else
-								buffer[mac] = vals
-								puts "Found node. MAC: #{mac}, name: #{host}"
+								buffer[id] = vals
+								puts "Found node. ID: #{id}, name: #{host}"
 							end
 						else
-							if buffer.key?(mac)
-								buffer[mac] = vals
-								puts "This MAC already existed in the unprocessed list, but its name has been overwritten to the new one."
+							if buffer.key?(id)
+								buffer[id] = vals
+								puts "This ID already existed in the unprocessed list, but its name has been overwritten to the new one."
 							elsif search_hostname.search(buffer,host)
-								buffer[mac] = vals
-								puts "Found node. MAC: #{mac}, name: #{host}"
+								buffer[id] = vals
+								puts "Found node. ID: #{id}, name: #{host}"
 								puts "Node added, but please note that the name of this node already exists in the unprocessed
 								list. It will be renamed during parsing anyway, but is useful to keep in mind."						
-							elsif parsed.key?(mac)
-								buffer[mac] = vals
-								puts "Node added, but please note that this MAC address already exists in the parsed parsed."
+							elsif parsed.key?(id)
+								buffer[id] = vals
+								puts "Node added, but please note that this ID address already exists in the parsed parsed."
 							elsif search_hostname.search(parsed,host)
-								buffer[mac] = vals
+								buffer[id] = vals
 								puts "Node added, but please note that a node with this hostname already exists in the parsed list."
 							else
-								buffer[mac] = vals
-								puts "Found node. MAC: #{mac}, name: #{host}"
+								buffer[id] = vals
+								puts "Found node. ID: #{id}, name: #{host}"
 							end
 						end						
 					end

--- a/lib/flight_hunter/server/list.rb
+++ b/lib/flight_hunter/server/list.rb
@@ -44,19 +44,19 @@ module FlightHunter
 		private
 	
 			def list_plain(list)
-				list.each do |mac,vals|
-					puts "#{mac},#{list[mac]["hostname"]},#{list[mac]["ip"] || "unknown"},#{list[mac].length > 1}"
+				list.each do |id,vals|
+					puts "#{id},#{list[id]["hostname"]},#{list[id]["ip"] || "unknown"},#{list[id].length > 1}"
 				end
 			end
 	
 			def list_table(list)
 				table = <<~TABLE.chomp
-					| MAC address | Name | Last Known IP | Has payload? |
-					|-------------|------|---------------|--------------|
+					| ID       | Name    | Last Known IP | Has payload? |
+					|----------|---------|---------------|--------------|
 				TABLE
 
-				all = list.reduce(table) do |memo, (mac,vals)|
-					"#{memo}\n| #{mac} | #{list[mac]["hostname"]} | #{list[mac]["ip"] || "unknown"} | #{list[mac].length > 1} |"
+				all = list.reduce(table) do |memo, (id,vals)|
+					"#{memo}\n| #{id} | #{list[id]["hostname"]} | #{list[id]["ip"] || "unknown"} | #{list[id].length > 1} |"
 				end
 				puts TTY::Markdown.parse(all)
 			end

--- a/lib/flight_hunter/server/manual.rb
+++ b/lib/flight_hunter/server/manual.rb
@@ -41,7 +41,7 @@ module FlightHunter
 					input = STDIN.gets.chomp
 					input=vals["hostname"] if input.empty?
 					if parsed.key?(id) || hostsearch.search(parsed,input)						
-						if parsed.key?(is)			
+						if parsed.key?(id)			
 							existing.push([id,parsed[id]])
 						end
 						if hostsearch.search(parsed,input)

--- a/lib/flight_hunter/server/manual.rb
+++ b/lib/flight_hunter/server/manual.rb
@@ -36,13 +36,13 @@ module FlightHunter
 				buffer = YAML.load(File.read(buffer_file)) || {}
 				existing = []
 				hostsearch = SearchHostname.new
-				buffer.each do |mac,vals|
-					puts "Enter name for MAC \"#{mac}\" [#{vals["hostname"]}]: "
+				buffer.each do |id,vals|
+					puts "Enter name for ID \"#{id}\" [#{vals["hostname"]}]: "
 					input = STDIN.gets.chomp
 					input=vals["hostname"] if input.empty?
-					if parsed.key?(mac) || hostsearch.search(parsed,input)						
-						if parsed.key?(mac)			
-							existing.push([mac,parsed[mac]])
+					if parsed.key?(id) || hostsearch.search(parsed,input)						
+						if parsed.key?(is)			
+							existing.push([id,parsed[id]])
 						end
 						if hostsearch.search(parsed,input)
 							parsed.each do |key,value|
@@ -56,7 +56,7 @@ module FlightHunter
 						existing.each { |element| puts "#{element[0]}: #{element[1]}"}
 						existing.each { |element| parsed.delete(element[0])}
 					end
-					parsed[mac] = {"hostname" => input, "ip" => vals["ip"], "payload" => vals["payload"]}.compact
+					parsed[id] = {"hostname" => input, "ip" => vals["ip"], "payload" => vals["payload"]}.compact
 				end
 				File.open(parsed_file,'w+') {|file| file.write(parsed.to_yaml)}
 				File.write(buffer_file,'---')

--- a/lib/flight_hunter/server/modify_id.rb
+++ b/lib/flight_hunter/server/modify_id.rb
@@ -27,36 +27,16 @@
 # For more information on Hunter, please visit:
 # https://github.com/openflighthpc/hunter
 #===============================================================================
-require 'tty-markdown'
 
 module FlightHunter
-	module Server
-		class ShowNode
-			def show_node(parsed, name)
-				list = YAML.load(File.read(parsed)) || {}
-				if list.nil? || list.empty?
-					puts "The list is empty."
-				else
-					list.each do |mac,vals|
-						if vals["hostname"] == name
-							table = <<~TABLE.chomp
-								| MAC address | Name |
-								|-------------|------|
-								| #{mac} | #{vals["hostname"]} |
-							TABLE
-
-							puts TTY::Markdown.parse(table)
-							if vals.key?("payload")
-								puts vals["payload"]
-							else
-								puts "#{name} has no payload associated with it."
-							end
-							return
-						end
-					end
-					puts "Could not find a node with name #{name}."
-				end
-			end
-		end
-	end
+  module Server
+    class ModifyID
+      def modify_id(list_file,oldid,newid)
+      	list = YAML.load(File.read(list_file))
+      	list[newid] = list.delete(oldid)
+      	File.write(list_file,list.to_yaml)
+      	puts "#{oldid} renamed to #{newid}."
+      end
+    end
+  end
 end

--- a/lib/flight_hunter/server/modify_name.rb
+++ b/lib/flight_hunter/server/modify_name.rb
@@ -34,15 +34,15 @@ module FlightHunter
       def modify_name(list_file,oldname,newname)
       	list = YAML.load(File.read(list_file))
         to_change = ""
-        list.each do |mac,vals|
-          if oldname == vals["hostname"]
-            to_change = mac
+        list.each do |id,vals|
+          if oldname ==vals["hostname"]
+            to_change = id
           end
         end
 
       	list[to_change]["hostname"] = newname
       	File.write(list_file,list.to_yaml)
-      	puts "#{oldname} MAC changed to #{newname}"
+      	puts "#{oldname} ID changed to #{newname}"
       end
     end
   end

--- a/lib/flight_hunter/server/remove_id.rb
+++ b/lib/flight_hunter/server/remove_id.rb
@@ -30,12 +30,12 @@
 
 module FlightHunter
   module Server
-    class RemoveMac
-      def remove_mac(list_file,mac)
+    class RemoveID
+      def remove_id(list_file,id)
       	list = YAML.load(File.read(list_file))
-      	list.delete(mac)
+      	list.delete(id)
       	File.write(list_file,list.to_yaml)
-      	puts "#{mac} deleted."
+      	puts "#{id} deleted."
       end
     end
   end

--- a/lib/flight_hunter/server/remove_name.rb
+++ b/lib/flight_hunter/server/remove_name.rb
@@ -34,9 +34,9 @@ module FlightHunter
       def remove_name(list_file,hostname)
         list = YAML.load(File.read(list_file))
         to_remove = ""
-        list.each do |mac,vals|
+        list.each do |id,vals|
           if hostname[0] == vals["hostname"]
-            to_remove = mac
+            to_remove = id
           end
         end
         list.delete(to_remove)

--- a/lib/flight_hunter/server/show.rb
+++ b/lib/flight_hunter/server/show.rb
@@ -27,16 +27,36 @@
 # For more information on Hunter, please visit:
 # https://github.com/openflighthpc/hunter
 #===============================================================================
+require 'tty-markdown'
 
 module FlightHunter
-  module Server
-    class ModifyMac
-      def modify_mac(list_file,oldmac,newmac)
-      	list = YAML.load(File.read(list_file))
-      	list[newmac] = list.delete(oldmac)
-      	File.write(list_file,list.to_yaml)
-      	puts "#{oldmac} renamed to #{newmac}."
-      end
-    end
-  end
+	module Server
+		class Show
+			def show(parsed, name)
+				list = YAML.load(File.read(parsed)) || {}
+				if list.nil? || list.empty?
+					puts "The list is empty."
+				else
+					list.each do |id,vals|
+						if vals["hostname"] == name
+							table = <<~TABLE.chomp
+								| ID          | Name |
+								|-------------|------|
+								| #{id}       | #{vals["hostname"]} |
+							TABLE
+
+							puts TTY::Markdown.parse(table)
+							if vals.key?("payload")
+								puts vals["payload"]
+							else
+								puts "#{name} has no payload associated with it."
+							end
+							return
+						end
+					end
+					puts "Could not find an entry with name #{name}."
+				end
+			end
+		end
+	end
 end

--- a/lib/flight_hunter/server/show.rb
+++ b/lib/flight_hunter/server/show.rb
@@ -32,26 +32,32 @@ require 'tty-markdown'
 module FlightHunter
 	module Server
 		class Show
-			def show(parsed, name)
+			def show(parsed, name, plain=false)
 				list = YAML.load(File.read(parsed)) || {}
 				if list.nil? || list.empty?
 					puts "The list is empty."
 				else
 					list.each do |id,vals|
 						if vals["hostname"] == name
-							table = <<~TABLE.chomp
-								| ID          | Name |
-								|-------------|------|
-								| #{id}       | #{vals["hostname"]} |
-							TABLE
+							if !plain
+								table = <<~TABLE.chomp
+									| ID          | Name |
+									|-------------|------|
+									| #{id}       | #{vals["hostname"]} |
+								TABLE
 
-							puts TTY::Markdown.parse(table)
-							if vals.key?("payload")
-								puts vals["payload"]
+								puts TTY::Markdown.parse(table)
+								if vals.key?("payload")
+									puts vals["payload"]
+								else
+									puts "#{name} has no payload associated with it."
+								end
+								return
 							else
-								puts "#{name} has no payload associated with it."
+								puts "#{id}: #{name}"
+								puts vals["payload"] rescue false
+								return
 							end
-							return
 						end
 					end
 					puts "Could not find an entry with name #{name}."


### PR DESCRIPTION
turns out our plan for using mac as the key can't be relied upon, particularly when using the macaddr lib as the mac that returns changes depending on which interface you boot from, and is never necessarily the boot interface. 

Trying out a slightly different use case for the tool
1 - use hostid as the key (apparently thats tied to the mainboard so shouldn't ever change. 
2 - the large inventory data zip is overkill for what I need atm so have included functionality ato attempt a basic info collection and pushing that via the payload if no zip file is specified. 

dev rpm build plz stuwie so i can test