### PR TITLE
Added groups

### DIFF
--- a/bin/hunter
+++ b/bin/hunter
@@ -73,6 +73,8 @@ require 'flight_hunter/server/remove_name'
 require 'flight_hunter/server/modify_port'
 require 'flight_hunter/server/modify_id'
 require 'flight_hunter/server/modify_name'
+require 'flight_hunter/server/modify_group'
+require 'flight_hunter/server/rename_group'
 require 'flight_hunter/server/dump_buffer'
 require 'flight_hunter/server/show'
 
@@ -90,10 +92,10 @@ module FlightHunter
     program :version, '0.0.3'
     program :description, 'MAC collection tool' 
     program :help_paging, false
+    default_command :help    
 
     buffer = Config.join_server_content('buffer.yaml')
     parsed = Config.join_server_content('parsed.yaml')
-
     [buffer, parsed].each do |file|
       if not File.file?(file)
         FileUtils.mkdir_p Config.join_server_content
@@ -149,10 +151,12 @@ module FlightHunter
     command 'list-parsed' do |c|
       c.summary = 'List the parsed nodes.'
       c.option '--plain', 'Plain output (csv)'
+      c.option '--group GROUP', 'List by group'
       c.action do |args, options|
-        Server::ListNodes.new.list_nodes(parsed,options.plain)
+        Server::ListNodes.new.list_nodes(parsed,options.plain, options.group)
       end
     end
+
     command 'show' do |c|
       c.syntax = "#{ program(:name) } NAME"
       c.summary = 'Show the details of a particular entry.'
@@ -221,6 +225,25 @@ module FlightHunter
       c.action do |args, _|
         oldname, newname = args
         Server::ModifyName.new.modify_name(parsed, oldname, newname)
+      end
+    end
+ 
+    command 'modify-group' do |c|
+      c.syntax = "#{program(:name) } NAME MODIFICATIONS"
+      c.summary = "Change groups of a node"
+      c.description = "Modifications format is:,+<grouptoadd>,-<grouptoremove>. \n e.g. ,+A,-B,+C,+D,-Z \n Changes are evaluated left to right, and any number of changes is allowed"
+      c.action do |args, _|
+        name, modifications = args
+        Server::ModifyGroup.new.modify_group(parsed, name, modifications)
+      end
+    end
+
+		command 'rename-group' do |c|
+      c.syntax = "#{program(:name) } OLDNAME NEWNAME"
+      c.summary = "Change the name of a group."
+      c.action do |args, _|
+        old_name, new_name = args
+        Server::RenameGroup.new.rename_group(parsed, old_name, new_name)
       end
     end
 

--- a/lib/flight_hunter/server/rename_group.rb
+++ b/lib/flight_hunter/server/rename_group.rb
@@ -27,45 +27,29 @@
 # For more information on Hunter, please visit:
 # https://github.com/openflighthpc/hunter
 #===============================================================================
-require 'tty-markdown'
 
 module FlightHunter
-	module Server
-		class Show
-			def show(parsed, name, plain=false)
-				list = YAML.load(File.read(parsed)) || {}
-				if list.nil? || list.empty?
-					puts "The list is empty."
-				else
-					list.each do |id,vals|
-						if vals["hostname"] == name
-							if !plain
-								group_name = "nil"
-								unless vals["group"] == nil then group_name = vals["group"] end
-								
-								table = <<~TABLE.chomp
-									| ID          | Name | Group |
-									|-------------|------|-------|
-									| #{id}       | #{vals["hostname"]} | #{vals["group"] || "none" }  |
-								TABLE
-
-								puts TTY::Markdown.parse(table)
-								if vals.key?("payload")
-									puts vals["payload"]
-								else
-									puts "#{name} has no payload associated with it."
-								end
-								return
-							else
-								puts "#{id}: #{name}"
-								puts vals["payload"] rescue false
-								return
-							end
+  module Server
+    class RenameGroup
+      def rename_group(list_file, old_name, new_name)
+      	list = YAML.load(File.read(list_file))
+				counter = 0
+				list.each do |id,vals|
+					if i = (list[id]["group"] or [] ).index(old_name)
+						if (list[id]["group"] or []).include?(new_name)
+							list[id]["group"][i] = nil
+							list[id]["group"].compact!
+						else
+							list[id]["group"][i] = new_name
 						end
+						counter+=1
 					end
-					puts "Could not find an entry with name #{name}."
 				end
+
+
+				File.write(list_file,list.to_yaml)
+				puts "Group \'#{old_name}\' renamed to \'#{new_name}\' for #{counter} nodes" 
 			end
-		end
-	end
+    end
+  end
 end


### PR DESCRIPTION
All nodes can now be part of a group. By default their group is "none" which means that the group in data is nil.

Added several functions to do with groups:
Rename_group allows user to rename a group. All nodes within the group will be shown to have a differently named group.

Modify-group allows user to modify a node's groups. Any number of groups can be added or removed in a single command, to a single node.

Changed List-Parsed to display groups in addition to what it displayed previously.

Changed Show to display groups in addition to what it displayed previously.