### PR TITLE
Replace method call that doesn't exist

### DIFF
--- a/lib/hunter/commands/modify_label.rb
+++ b/lib/hunter/commands/modify_label.rb
@@ -45,7 +45,7 @@ module Hunter
           raise "Node '#{old_label}' does not exist in list '#{list.name}'"
         end
 
-        node.modify_label(new_label)
+        node.label = new_label
 
         if list.save
           puts "Node '#{old_label}' in list '#{list.name}' relabeled to '#{new_label}'"


### PR DESCRIPTION
- Replaced non-existent `modify_label` method call with use of the setter provided by `attr_accessor`.

Resolves #13 when merged.