### PR TITLE
Use target host when sending to self if possible

### DIFF
--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -65,7 +65,7 @@ module Hunter
           if first && (@options.include_self || Config.include_self)
             opts = OpenStruct.new(
               port: port,
-              server: 'localhost'
+              server: Config.target_host || 'localhost'
             )
 
             Commands::SendPayload.new(OpenStruct.new, opts).run!


### PR DESCRIPTION
As title. Means that when `target_host` is set, the hunting node will note down a relevant IP instead of just `localhost`.