### PR TITLE
Reload the node lists each time a new node is found

### DIFF
--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -39,8 +39,6 @@ module Hunter
         port = @options.port || Config.port
         raise "No port provided!" if !port
 
-        buffer = NodeList.load(Config.node_buffer)
-        parsed = NodeList.load(Config.node_list)
         server = TCPServer.open(port)
 
         puts "Hunter running on #{server.addr[3]}:#{server.addr[1]} Ctrl+C to stop\n"
@@ -70,6 +68,7 @@ module Hunter
 
             Commands::SendPayload.new(OpenStruct.new, opts).run!
           end
+
           client = server.accept
           first = false
           hostid, hostname, payload = client.read.unpack("Z*Z*Z*")
@@ -95,6 +94,9 @@ module Hunter
           IP: #{node.ip}
 
           EOF
+
+          buffer = NodeList.load(Config.node_buffer)
+          parsed = NodeList.load(Config.node_list)
 
           if @options.allow_existing || Config.allow_existing
             buffer.nodes.delete_if { |n| n.id == node.id }


### PR DESCRIPTION
This PR updates the `hunt` command to load in the buffer and parsed lists every loop when a new node is picked up. Race conditions with reading/saving the buffer list are impossible because the process only ever runs on one thread, refusing new nodes until the 'current' one has been resolved.
Resolves #18 when merged.