### PR TITLE
Expand send command

### DIFF
--- a/lib/hunter/cli.rb
+++ b/lib/hunter/cli.rb
@@ -151,9 +151,9 @@ module Hunter
       c.slop.string '-f', '--file', "Specify a payload file"
       c.slop.string '-s', '--server', "Override server hostname"
       c.slop.integer '-p', '--port', "Override server port"
-      c.slop.string "--label", "Specify a lable to use for this node"
+      c.slop.string "--label", "Specify a label to use for this node"
       c.slop.string "--prefix", "Specify a prefix to use for this node"
-      c.slop.string "--group", "Specify a group for this node"
+      c.slop.array "--groups", "Specify a comma-separated list of groups for this node"
       c.action Commands, :send_payload
     end
   end

--- a/lib/hunter/cli.rb
+++ b/lib/hunter/cli.rb
@@ -151,7 +151,6 @@ module Hunter
       c.slop.string '-f', '--file', "Specify a payload file"
       c.slop.string '-s', '--server', "Override server hostname"
       c.slop.integer '-p', '--port', "Override server port"
-      c.slop.string '--spoof', "Override system hostname"
       c.action Commands, :send_payload
     end
   end

--- a/lib/hunter/cli.rb
+++ b/lib/hunter/cli.rb
@@ -151,6 +151,9 @@ module Hunter
       c.slop.string '-f', '--file', "Specify a payload file"
       c.slop.string '-s', '--server', "Override server hostname"
       c.slop.integer '-p', '--port', "Override server port"
+      c.slop.string "--label", "Specify a lable to use for this node"
+      c.slop.string "--prefix", "Specify a prefix to use for this node"
+      c.slop.string "--group", "Specify a group for this node"
       c.action Commands, :send_payload
     end
   end

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -78,11 +78,12 @@ module Hunter
             hostname: hostname,
             ip: (client.peeraddr[2] || 'unknown'),
             payload: payload,
-            groups: groups,
+            groups: groups.split(","),
             label: nil,
-            presets: {label: label,
-                      prefix: prefix
-                     }
+            presets: {
+              label: label,
+              prefix: prefix
+            }
           )
 
           puts <<~EOF

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -71,14 +71,16 @@ module Hunter
 
           client = server.accept
           first = false
-          hostid, hostname, payload = client.read.unpack("Z*Z*Z*")
+          hostid, hostname, payload, label, prefix, group = client.read.unpack("Z*Z*Z*Z*Z*Z*")
 
           node = Node.new(
             id: hostid,
             hostname: hostname,
             ip: (client.peeraddr[2] || 'unknown'),
             payload: payload,
-            groups: []
+            groups: [group],
+            label: label,
+            prefix: prefix
           )
 
           puts <<~EOF

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -79,8 +79,10 @@ module Hunter
             ip: (client.peeraddr[2] || 'unknown'),
             payload: payload,
             groups: groups,
-            label: label,
-            prefix: prefix
+            label: nil,
+            presets: {label: label,
+                      prefix: prefix
+                     }
           )
 
           puts <<~EOF

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -73,12 +73,6 @@ module Hunter
           first = false
           hostid, hostname, payload = client.read.unpack("Z*Z*Z*")
 
-          node = {
-            "hostname" => hostname,
-            "ip" => (client.peeraddr[2] || 'unknown'),
-            "payload" => payload
-          }.reject { |k,v| v.empty? }
-
           node = Node.new(
             id: hostid,
             hostname: hostname,

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -71,14 +71,14 @@ module Hunter
 
           client = server.accept
           first = false
-          hostid, hostname, payload, label, prefix, group = client.read.unpack("Z*Z*Z*Z*Z*Z*")
+          hostid, hostname, payload, label, prefix, groups = client.read.unpack("Z*Z*Z*Z*Z*Z*")
 
           node = Node.new(
             id: hostid,
             hostname: hostname,
             ip: (client.peeraddr[2] || 'unknown'),
             payload: payload,
-            groups: [group],
+            groups: groups,
             label: label,
             prefix: prefix
           )

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -61,7 +61,7 @@ module Hunter
           file_content = Collector.collect.to_yaml
         end
 
-        hostname = @options.spoof || Socket.gethostname
+        hostname = Socket.gethostname
 
         payload = [hostid, hostname, file_content].pack('Z*Z*Z*')
 

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -63,7 +63,8 @@ module Hunter
 
         hostname = Socket.gethostname
 
-        payload = [hostid, hostname, file_content].pack('Z*Z*Z*')
+        puts @options.prefix
+        payload = [hostid, hostname, file_content, @options.label, @options.prefix, @options.group].pack('Z*Z*Z*Z*Z*Z*')
 
         begin
           server = TCPSocket.open(host, port)

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -63,7 +63,7 @@ module Hunter
 
         hostname = Socket.gethostname
 
-        payload = [hostid, hostname, file_content, @options.label, @options.prefix, @options.group].pack('Z*Z*Z*Z*Z*Z*')
+        payload = [hostid, hostname, file_content, @options.label, @options.prefix, @options.groups.join(",")].pack('Z*Z*Z*Z*Z*Z*')
 
         begin
           server = TCPSocket.open(host, port)

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -63,7 +63,6 @@ module Hunter
 
         hostname = Socket.gethostname
 
-        puts @options.prefix
         payload = [hostid, hostname, file_content, @options.label, @options.prefix, @options.group].pack('Z*Z*Z*Z*Z*Z*')
 
         begin

--- a/lib/hunter/node.rb
+++ b/lib/hunter/node.rb
@@ -35,7 +35,7 @@ module Hunter
         'ip' => ip,
         'payload' => payload,
         'groups' => groups,
-        'prefix' => prefix
+        'presets' => presets
       }
     end
 
@@ -47,17 +47,17 @@ module Hunter
       @groups = @groups - to_remove
     end
 
-    attr_reader :id, :ip, :payload, :groups, :hostname, :prefix
+    attr_reader :id, :ip, :payload, :groups, :hostname, :presets
     attr_accessor :label
 
-    def initialize(id:, hostname:, label: nil, ip:, payload:, groups: [], prefix: nil)
+    def initialize(id:, hostname:, label: nil, ip:, payload:, groups: [], presets: {})
       @id = id
       @hostname = hostname
       @label = label
       @ip = ip
       @payload = payload
       @groups = groups || []
-      @prefix = prefix
+      @presets = presets
     end
 
     private

--- a/lib/hunter/node.rb
+++ b/lib/hunter/node.rb
@@ -34,7 +34,8 @@ module Hunter
         'label' => label,
         'ip' => ip,
         'payload' => payload,
-        'groups' => groups
+        'groups' => groups,
+        'prefix' => prefix
       }
     end
 
@@ -46,16 +47,17 @@ module Hunter
       @groups = @groups - to_remove
     end
 
-    attr_reader :id, :ip, :payload, :groups, :hostname, :label
-    attr_accessor :label
+    attr_reader :id, :ip, :payload, :groups, :hostname, :label, :prefix
+    attr_accessor :label, :prefix
 
-    def initialize(id:, hostname:, label: nil, ip:, payload:, groups: [])
+    def initialize(id:, hostname:, label: nil, ip:, payload:, groups: [], prefix: nil)
       @id = id
       @hostname = hostname
       @label = label
       @ip = ip
       @payload = payload
       @groups = groups || []
+      @prefix = prefix
     end
 
     private

--- a/lib/hunter/node.rb
+++ b/lib/hunter/node.rb
@@ -47,8 +47,8 @@ module Hunter
       @groups = @groups - to_remove
     end
 
-    attr_reader :id, :ip, :payload, :groups, :hostname, :label, :prefix
-    attr_accessor :label, :prefix
+    attr_reader :id, :ip, :payload, :groups, :hostname, :prefix
+    attr_accessor :label
 
     def initialize(id:, hostname:, label: nil, ip:, payload:, groups: [], prefix: nil)
       @id = id


### PR DESCRIPTION
This PR gives the option to send three additional strings with the `send` command - `label`, `prefix` and `group`. All are stored as attributes of the node, and are sent out alongside the payload.