### PR TITLE
Pass buffer to search_field

### DIFF
--- a/lib/hunter/commands/modify_groups.rb
+++ b/lib/hunter/commands/modify_groups.rb
@@ -43,10 +43,10 @@ module Hunter
           when true
             list.match(Regexp.new(args[0]))
           when false
-            [list.find(search_field => args[0])]
+            [list.find(search_field(buffer) => args[0])]
           end
         
-        raise "No #{search_field}s in list '#{list.name}' match pattern '#{args[0]}'" unless nodes.any?
+        raise "No #{search_field(buffer)}s in list '#{list.name}' match pattern '#{args[0]}'" unless nodes.any?
 
         nodes.each do |n|
           n.add_groups(to_add)

--- a/lib/hunter/commands/remove_node.rb
+++ b/lib/hunter/commands/remove_node.rb
@@ -42,10 +42,10 @@ module Hunter
           when true
             list.match(Regexp.new(args[0]))
           when false
-            [list.find(search_field =>  args[0])]
+            [list.find(search_field(buffer) =>  args[0])]
           end
         
-        raise "No #{search_field}s in list '#{list.name}' match pattern '#{args[0]}'" unless nodes&.any?
+        raise "No #{search_field(buffer)}s in list '#{list.name}' match pattern '#{args[0]}'" unless nodes&.any?
 
         if list.delete(nodes) && list.save
           puts "The following nodes have successfully been removed from list '#{list.name}'"

--- a/lib/hunter/commands/show.rb
+++ b/lib/hunter/commands/show.rb
@@ -35,9 +35,9 @@ module Hunter
         list_file = @buffer ? Config.node_buffer : Config.node_list
         list = NodeList.load(list_file)
 
-        node = list.find(search_field => args[0])
+        node = list.find(search_field(@buffer) => args[0])
 
-        raise "Node with #{search_field} '#{args[0]}' doesn't exist in list '#{list.name}'" if !node
+        raise "Node with #{search_field(@buffer)} '#{args[0]}' doesn't exist in list '#{list.name}'" if !node
 
         if @options.plain
           a = [


### PR DESCRIPTION
This PR fixes the `show`, `remove-node` and `modify-group` commands when using the `--buffer` option.