### PR TITLE
Improved payload sending

### DIFF
--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -78,7 +78,7 @@ module Hunter
             headers[line[0].chop] = line[1].strip
           end
           
-          if headers["Content-Type"] == "hunter-node"
+          if headers["Content-Type"] == "application/json"
             data = client.read(headers["Content-Length"].to_i)
 
             payload = YAML.load(data)

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -29,7 +29,6 @@ require 'socket'
 require 'yaml'
 require 'json'
 require 'net/http'
-require 'uri'
 
 require_relative '../command'
 require_relative '../collector'
@@ -65,21 +64,24 @@ module Hunter
 
         hostname = Socket.gethostname
 
-        uri = URI.parse("http://" + host + ":" + port)
-
-        header = {'Content-Type': 'hunter-node'}
-        
-        data = {hostid: hostid,
-                hostname: hostname,
-                file_content: file_content,
-                label: @options.label,
-                prefix: @options.prefix,
-                groups: @options.groups
-               }
+        uri = URI::HTTPS.build(host: host, port: port)
 
         http = Net::HTTP.new(uri.host, uri.port)
-        request = Net::HTTP::Post.new(uri.request_uri, header)
-        request.body = data.to_yaml
+        request = Net::HTTP::Post.new(
+          uri,
+          'Content-Type' => 'application/json'
+        )
+
+        data = {
+          hostid: hostid,
+          hostname: hostname,
+          file_content: file_content,
+          label: @options.label,
+          prefix: @options.prefix,
+          groups: @options.groups
+        }
+
+        request.body = data.to_json
         
         begin
           response = http.request(request)

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -39,7 +39,7 @@ module Hunter
 
       def run
         host = @options.server || Config.target_host
-        port = @options.port || Config.port
+        port = @options.port || Config.port.to_s
 
         raise "No target_host provided!" if !host
         raise "No port provided!" if !port


### PR DESCRIPTION
This PR sets the `send` command's payload to be YAML data representing the information it was previously sending. This comes with some advantages:

* Adding/removing fields from the payload is easier
* Data can be received on a machine running `hunt` from any machine that may send a HTTP POST request - requests with a content type of `hunter-node` will be read, while other data received on the chosen port will be ignored (originally this would create a blank/broken entry in the buffer). Other machines don't necessarily need to use Flight-Hunter to send this data.
* Although less useful, this change also allows the `send` command to send data to sources besides machines running `hunt` - I can't think of any use cases for this myself but it's still bonus functionality.