### PR TITLE
Authentication on sent messages

### DIFF
--- a/etc/config.yml.ex
+++ b/etc/config.yml.ex
@@ -16,3 +16,6 @@
 #
 # Allow existing nodes when hunting
 # allow_existing: false
+#
+# Key used to authenticate data
+# auth_key: flight-hunter

--- a/lib/hunter/cli.rb
+++ b/lib/hunter/cli.rb
@@ -63,6 +63,7 @@ module Hunter
       c.slop.bool '--allow-existing', 'Allow replacement of existing entries'
       c.slop.string '--port', 'Override port'
       c.slop.bool '--include-self', 'Immediately try to send payload to self'
+      c.slop.string "--auth", "Override default authentication key"
       c.action Commands, :hunt
     end
 
@@ -154,6 +155,7 @@ module Hunter
       c.slop.string "--label", "Specify a label to use for this node"
       c.slop.string "--prefix", "Specify a prefix to use for this node"
       c.slop.array "--groups", "Specify a comma-separated list of groups for this node"
+      c.slop.string "--auth", "Override default authentication key"
       c.action Commands, :send_payload
     end
   end

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -84,19 +84,19 @@ module Hunter
 
             payload = JSON.parse(data)
 
-            client.puts "HTTP/1.1 200\r\n"
-            
-            node = Node.new(
-              id: payload['hostid'],
-              hostname: payload['hostname'],
-              ip: (client.peeraddr[2] || 'unknown'),
-              payload: payload['file_content'],
-              groups: payload['groups'],
-              presets: {
-                label: payload['label'],
-                prefix: payload['prefix']
-              }
-            )
+            if payload["auth_key"] == auth_key
+              client.puts "HTTP/1.1 200\r\n"
+              node = Node.new(
+                id: payload["hostid"],
+                hostname: payload["hostname"],
+                ip: (client.peeraddr[2] || 'unknown'),
+                payload: payload["file_content"],
+                groups: payload["groups"],
+                presets: {
+                  label: payload["label"],
+                  prefix: payload["prefix"]
+                }
+              )
 
               puts <<~EOF
               Found node.

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -37,6 +37,7 @@ module Hunter
     class Hunt < Command
       def run
         port = @options.port || Config.port
+        auth_key = @options.auth || Config.auth_key
         raise "No port provided!" if !port
 
         server = TCPServer.open(port)
@@ -97,33 +98,37 @@ module Hunter
               }
             )
 
-            puts <<~EOF
-            Found node.
-            ID: #{node.id}
-            Name: #{node.hostname}
-            IP: #{node.ip}
+              puts <<~EOF
+              Found node.
+              ID: #{node.id}
+              Name: #{node.hostname}
+              IP: #{node.ip}
 
-            EOF
+              EOF
 
-            buffer = NodeList.load(Config.node_buffer)
-            parsed = NodeList.load(Config.node_list)
+              buffer = NodeList.load(Config.node_buffer)
+              parsed = NodeList.load(Config.node_list)
 
-            if @options.allow_existing || Config.allow_existing
-              buffer.nodes.delete_if { |n| n.id == node.id }
-              buffer.nodes << node
-              puts "Node added to buffer"
-            else
-              if buffer.include_id?(node.id)
-                puts "ID already exists in buffer"
-              elsif parsed.include_id?(node.id)
-                puts "ID already exists in parsed node list"
-              else
+              if @options.allow_existing || Config.allow_existing
+                buffer.nodes.delete_if { |n| n.id == node.id }
                 buffer.nodes << node
                 puts "Node added to buffer"
+              else
+                if buffer.include_id?(node.id)
+                  puts "ID already exists in buffer"
+                elsif parsed.include_id?(node.id)
+                  puts "ID already exists in parsed node list"
+                else
+                  buffer.nodes << node
+                  puts "Node added to buffer"
+                end
               end
-            end
 
-            buffer.save
+              buffer.save
+            else
+              client.puts "HTTP/1.1 401\r\n"
+              puts "Unauthorised node attempted to connect"
+            end
           end
           client.close
         end

--- a/lib/hunter/config.rb
+++ b/lib/hunter/config.rb
@@ -68,6 +68,10 @@ module Hunter
       def allow_existing
         ENV['flight_HUNTER_allow_existing'] || data.fetch(:allow_existing)
       end
+      
+      def auth_key
+        ENV['flight_HUNTER_auth_key'] || data.fetch(:auth_key)
+      end
 
       def node_buffer
         var_file('buffer.yaml')


### PR DESCRIPTION
This PR introduces some basic authentication for data sent/received. Sent data now has an `auth_key` field, which defaults to a value set in `config.yml` but may be set either via an environment variable or using the new `--auth` option, which is available in both the `send` and `hunt` commands - should a machine running `hunt` receive data sent to it without matching authentication keys, the `hunt`ing machine notifies the user and the `send`ing machine raises an error informing the user there was an authentication key mismatch.

NB This PR depends heavily on the changes made in #30 