### PR TITLE
Fix hanging when `--include-self` used

### DIFF
--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -57,10 +57,8 @@ module Hunter
           )
         end
 
-        first = true
-
-        loop do
-          if first && (@options.include_self || Config.include_self)
+        Thread.new do
+          if @options.include_self || Config.include_self
             opts = OpenStruct.new(
               port: port,
               server: Config.target_host || 'localhost'
@@ -68,9 +66,10 @@ module Hunter
 
             Commands::SendPayload.new(OpenStruct.new, opts).run!
           end
+        end
 
+        loop do
           client = server.accept
-          first = false
 
           headers = {}
           while line = client.gets.split(' ', 2)


### PR DESCRIPTION
Previously, attempting to run the listening server with the `--include-self` flag was causing the server to stop accepting calls from any other machine, leading them to timeout. This seems to solve the issue.