### PR TITLE
Log the output of hunter when autorunning

### DIFF
--- a/bin/hunter
+++ b/bin/hunter
@@ -37,10 +37,6 @@ begin
 
   require 'hunter/cli'
   require 'hunter/prompt'
-  if $stdout.tty?
-    $stdout.reopen("out.txt", "w")
-    $stderr.reopen("out.txt", "w")
-  end
   Dir.chdir(ENV.fetch('FLIGHT_CWD','.'))
   OpenFlight.set_standard_env rescue nil
 

--- a/bin/hunter
+++ b/bin/hunter
@@ -37,6 +37,10 @@ begin
 
   require 'hunter/cli'
   require 'hunter/prompt'
+  if $stdout.tty?
+    $stdout.reopen("out.txt", "w")
+    $stderr.reopen("out.txt", "w")
+  end
   Dir.chdir(ENV.fetch('FLIGHT_CWD','.'))
   OpenFlight.set_standard_env rescue nil
 

--- a/bin/start
+++ b/bin/start
@@ -13,4 +13,4 @@ install_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd)"
 
 exec \
   env flight_HUNTER_pidfile=$1 \
-  "${flight_ROOT}"/bin/flexec ruby $install_dir/bin/hunter autorun
+  "${flight_ROOT}"/bin/flexec ruby $install_dir/bin/hunter autorun |& tee $install_dir/var/log/log.txt

--- a/bin/start
+++ b/bin/start
@@ -11,6 +11,8 @@ fi
 
 install_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd)"
 
+mkdir -p $install_dir/var/log
+
 exec \
   env flight_HUNTER_pidfile=$1 \
   "${flight_ROOT}"/bin/flexec ruby $install_dir/bin/hunter autorun |& tee $install_dir/var/log/log.txt


### PR DESCRIPTION
This PR enables hunter to dump both standard output and error to a log file at `var/log/log.txt` when it is run as a background process through `flight-service`