### PR TITLE
Always authorise self

### DIFF
--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -62,7 +62,8 @@ module Hunter
           if @options.include_self || Config.include_self
             opts = OpenStruct.new(
               port: port,
-              server: Config.target_host || 'localhost'
+              server: Config.target_host || 'localhost',
+              auth: auth_key
             )
 
             Commands::SendPayload.new(OpenStruct.new, opts).run!


### PR DESCRIPTION
This PR fixes the clash between the implementation of `--include-self` and `--auth`. A node will now always be authorised when sending to itself.