### PR TITLE
Handle invalid start option

### DIFF
--- a/lib/hunter/commands/parse.rb
+++ b/lib/hunter/commands/parse.rb
@@ -37,12 +37,9 @@ module Hunter
         raise "No nodes in buffer" if @buffer.nodes.empty?
         @parsed = NodeList.load(Config.node_list)
 
-
-        if !/\A\d+\z/.match(@options.start)
+        if @options.start && !/\A\d+\z/.match(@options.start)
           raise "Please provide a valid positive integer value for `--start`"
         end
-
-        @start = @options.start.to_i
 
         # Initialize label counts
         @label_increments = {}
@@ -79,7 +76,10 @@ module Hunter
       private
 
       def automatic_parse
-        if @buffer.nodes.group_by { |n| n.presets[:label] }.any? { |g| g.count > 1 }
+        duplicates = @buffer.nodes.group_by { |n| n.presets[:label] }
+                                  .reject { |k, v| k.nil? }
+                                  .any? { |k, v| v.count > 1 }
+        if duplicates
           raise "Duplicate preset labels in buffer list. Please resolve any duplicates before continuing."
         end
 
@@ -94,7 +94,9 @@ module Hunter
           prefix = node.presets[:prefix] || @options.prefix
           if node.presets[:label]
             label = node.presets[:label]
-          elsif prefix
+          elsif prefix && !@options.start
+            raise "Please provide a valid positive integer value for `--start`"
+          elsif prefix && @options.start
             loop do
               label = generate_label(prefix)
               
@@ -121,7 +123,7 @@ module Hunter
       end
 
       def generate_label(prefix)
-        start = @start
+        start = @options.start
 
         @label_increments[prefix] ||= { count: 0 }
         iteration = start.to_i + @label_increments[prefix][:count]
@@ -196,7 +198,9 @@ module Hunter
             prefix = node.presets[:prefix] || @options.prefix
             if node.presets[:label]
               node.presets[:label]
-            elsif prefix
+            elsif prefix && !@options.start
+              prefix
+            elsif prefix && @options.start
               loop do
                 label = generate_label(prefix)
 

--- a/lib/hunter/commands/parse.rb
+++ b/lib/hunter/commands/parse.rb
@@ -37,6 +37,13 @@ module Hunter
         raise "No nodes in buffer" if @buffer.nodes.empty?
         @parsed = NodeList.load(Config.node_list)
 
+
+        if !/\A\d+\z/.match(@options.start)
+          raise "Please provide a valid positive integer value for `--start`"
+        end
+
+        @start = @options.start.to_i
+
         # Initialize label counts
         @label_increments = {}
         @used_strings = [].tap do |a|
@@ -114,7 +121,7 @@ module Hunter
       end
 
       def generate_label(prefix)
-        start = @options.start
+        start = @start
 
         @label_increments[prefix] ||= { count: 0 }
         iteration = start.to_i + @label_increments[prefix][:count]


### PR DESCRIPTION
This PR adds some extra conditional logic to both the parsing methods to ensure that we don't attempt to use the `--start` option if it hasn't been provided. This PR also ensures that, if it's provided, the `--start` option is validated as a positive integer (although, still contained within a string). A bug was also fixed with regards to checking for duplicate preset labels in the buffer list.