### PR TITLE
Send command output

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A tool for tracking MAC addresses of nodes in a cluster.
 
 ## Overview
 
-Hunter facilitates a communication between two machines, allowing one machine to send some diagnostic data and a payload file to another machine listening for other nodes running Hunter.
+Hunter facilitates a communication between two machines, allowing one machine to send some data to another machine listening for other nodes running Hunter.
 
 ## Installation
 
@@ -36,7 +36,7 @@ Flight Hunter has some required configuration based on the environment it is bei
 - `target_host` - The hostname/IP for the client to attempt to send to.
 - `autorun_mode` - Which mode to run when running the `autorun` command. Must be one of `hunt` or `send`.
 - `include_self` - Toggle to automatically run `send` for itself when a `hunt` server is started.
-- `payload_file` - File to send as a payload when running `send`
+- `content_command` - A command which will be executed, with the output being sent when running `send`
 - `allow_existing` - Overwrite existing nodes when hunting/parsing a node that already exists
 - `auth_key` - Specify an authentication key allowing only nodes with a matching key to connect
 - `broadcast_address` - Specify an IP address range to use when using `send`'s broadcast mode.
@@ -52,7 +52,7 @@ A brief usage guide is given below. See the `help` command for further details a
 
 Run the Hunter listening server with `hunt`. By default, nodes that already exist in the Hunter nodelist are ignored. Override existing nodes with `hunt --allow-existing`. The server can immediately `send` to itself with `--include-self`.
 
-Run the Hunter payload transmitter with `send`. The system's hostid, IP, hostname, and a default payload of diagnostic data will be sent to the Hunter server running at the configured IP/port. The system hostname and payload can be overwritten via command line options. You may also provide a label or a prefix to use for the node's label when being parsed by the host machine.
+Run the Hunter payload transmitter with `send`. The system's hostid, IP, hostname, and a default chunk of diagnostic data will be sent to the Hunter server running at the configured IP/port. The system hostname and data content can be overwritten via command line options. You may also provide a label or a prefix to use for the node's label when being parsed by the host machine.
 
 The `send` command will, by default, attempt to establish a TCP connection with the given `target_host`. You may also use the `--broadcast` option, to send a UDP packet via a given broadcast address. Currently, the only format supported is:
 

--- a/etc/config.yml.ex
+++ b/etc/config.yml.ex
@@ -11,8 +11,8 @@
 # Automatically include self when hunting
 # include_self: false
 #
-# File to use as a payload
-# payload_file:
+# Command to use to generate content
+# content_command:
 #
 # Allow existing nodes when hunting
 # allow_existing: false

--- a/lib/hunter/cli.rb
+++ b/lib/hunter/cli.rb
@@ -149,16 +149,16 @@ module Hunter
 
     command :send do |c|
       cli_syntax(c)
-      c.summary = 'Push my identity plus optional payload to server'
-      c.slop.bool '--broadcast', "Send identity to all nodes on a given subnet"
-      c.slop.string '-f', '--file', "Specify a payload file"
-      c.slop.string '-s', '--server', "Override server hostname"
+      c.summary = 'Push my identity plus optional additional details to server'
+      c.slop.string '-c', '--command', "Command to use to generate sent content"
       c.slop.integer '-p', '--port', "Override server port"
+      c.slop.string '-s', '--server', "Override server hostname"
+      c.slop.string "--auth", "Override default authentication key"
+      c.slop.bool '--broadcast', "Send identity to all nodes on a given subnet"
       c.slop.string "--broadcast-address", "Specify a broadcast address to use if broadcasting"
+      c.slop.array "--groups", "Specify a comma-separated list of groups for this node"
       c.slop.string "--label", "Specify a label to use for this node"
       c.slop.string "--prefix", "Specify a prefix to use for this node"
-      c.slop.array "--groups", "Specify a comma-separated list of groups for this node"
-      c.slop.string "--auth", "Override default authentication key"
       c.action Commands, :send_payload
     end
   end

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -142,7 +142,7 @@ module Hunter
           id: data["hostid"],
           hostname: data["hostname"],
           ip: data["ip"],
-          payload: data["file_content"],
+          content: data["content"],
           groups: data["groups"],
           presets: {
             label: data["label"],

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -110,7 +110,7 @@ module Hunter
         {
           hostid: hostid,
           hostname: hostname,
-          file_content: file_content,
+          content: content,
           label: @options.label,
           prefix: @options.prefix,
           groups: @options.groups,

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -102,7 +102,7 @@ module Hunter
         if cmd.nil?
           content = Collector.collect.to_yaml
         else
-          content = `#{cmd}`
+          content = `#{cmd}`.chomp
         end
 
         hostname = Socket.gethostname

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -98,11 +98,11 @@ module Hunter
                     syshostid
                   end
 
-        payload_file = @options.file || Config.payload_file
-        if payload_file && File.file?(payload_file)
-          file_content = File.read(payload_file)
+        cmd = @options.command || Config.content_command
+        if cmd.nil?
+          content = Collector.collect.to_yaml
         else
-          file_content = Collector.collect.to_yaml
+          content = `#{cmd}`
         end
 
         hostname = Socket.gethostname

--- a/lib/hunter/commands/show.rb
+++ b/lib/hunter/commands/show.rb
@@ -52,7 +52,7 @@ module Hunter
           t.headers('ID', 'Label', 'Hostname', 'IP', 'Groups')
           t.row(node.id, node.label, node.hostname, node.ip, node.groups.join(", "))
           t.emit
-          puts node.payload
+          puts node.content
         end
       end
     end

--- a/lib/hunter/config.rb
+++ b/lib/hunter/config.rb
@@ -65,8 +65,8 @@ module Hunter
         ENV['flight_HUNTER_target_host'] || data.fetch(:target_host)
       end
 
-      def payload_file
-        ENV['flight_HUNTER_payload_file'] || data.fetch(:payload_file)
+      def content_command
+        ENV['flight_HUNTER_content_command'] || data.fetch(:content_command)
       end
 
       def allow_existing

--- a/lib/hunter/node.rb
+++ b/lib/hunter/node.rb
@@ -33,7 +33,7 @@ module Hunter
         'hostname' => hostname,
         'label' => label,
         'ip' => ip,
-        'payload' => payload,
+        'content' => content,
         'groups' => groups,
         'presets' => presets
       }
@@ -51,15 +51,15 @@ module Hunter
       presets.map { |k,v| "#{k}: '#{v}'" }.join("\n")
     end
 
-    attr_reader :id, :ip, :payload, :groups, :hostname, :presets
+    attr_reader :id, :ip, :content, :groups, :hostname, :presets
     attr_accessor :label
 
-    def initialize(id:, hostname:, label: nil, ip:, payload:, groups: [], presets: {})
+    def initialize(id:, hostname:, label: nil, ip:, content:, groups: [], presets: {})
       @id = id
       @hostname = hostname
       @label = label
       @ip = ip
-      @payload = payload
+      @content = content
       @groups = groups || []
       @presets = presets.reject { |k,v| v.nil? || v.empty? }
     end

--- a/lib/hunter/node_list.rb
+++ b/lib/hunter/node_list.rb
@@ -109,7 +109,7 @@ module Hunter
             hostname: node['hostname'],
             label: node['label'],
             ip: node['ip'],
-            payload: node['payload'],
+            content: node['content'],
             groups: node['groups'],
             presets: node['presets']
           )


### PR DESCRIPTION
This PR converts the `send` command's `--file` option into a more flexible `--command` option, which will be run in the console and its output sent as content.

This PR also makes numerous semantic changes to distinguish between the **payload** (the JSON data which is sent by `send`) and what is now known as the **content** (the data which is sent via the `--command` option).