### PR TITLE
Get and store MAC addresses

### DIFF
--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -61,13 +61,6 @@ module Hunter
 
         if @options.include_self || Config.include_self
           
-          # Get name of used interface
-          interface = `ip addr show | grep #{Config.target_host} -B 2 | head -n1 | awk '{print $2}'`[0..-3]
-          # Get mac of used interface
-          mac = `ip addr show #{interface} | grep link/ether | awk '{print $2}'`.chomp
-          # Add self to ARP cache
-          resp = `ip neigh add #{Config.target_host} dev #{interface} lladdr #{mac}`
-          
           opts = OpenStruct.new(
             port: @port,
             server: Config.target_host || 'localhost',

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -63,13 +63,10 @@ module Hunter
           
           # Get name of used interface
           interface = `ip addr show | grep #{Config.target_host} -B 2 | head -n1 | awk '{print $2}'`[0..-3]
-          puts "if is " + interface.inspect
           # Get mac of used interface
           mac = `ip addr show #{interface} | grep link/ether | awk '{print $2}'`.chomp
-          puts "mac is " + mac.inspect
           # Add self to ARP cache
           resp = `ip neigh add #{Config.target_host} dev #{interface} lladdr #{mac}`
-          puts resp
           
           opts = OpenStruct.new(
             port: @port,

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -60,6 +60,17 @@ module Hunter
         puts "Hunter running on port #{@port} - Ctrl+C to stop\n"
 
         if @options.include_self || Config.include_self
+          
+          # Get name of used interface
+          interface = `ip addr show | grep #{Config.target_host} -B 2 | head -n1 | awk '{print $2}'`[0..-3]
+          puts "if is " + interface.inspect
+          # Get mac of used interface
+          mac = `ip addr show #{interface} | grep link/ether | awk '{print $2}'`.chomp
+          puts "mac is " + mac.inspect
+          # Add self to ARP cache
+          resp = `ip neigh add #{Config.target_host} dev #{interface} lladdr #{mac}`
+          puts resp
+          
           opts = OpenStruct.new(
             port: @port,
             server: Config.target_host || 'localhost',

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -155,7 +155,8 @@ module Hunter
           presets: {
             label: data["label"],
             prefix: data["prefix"]
-          }
+          },
+          mac: data["mac"]
         )
 
         puts <<~EOF

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -60,7 +60,6 @@ module Hunter
         puts "Hunter running on port #{@port} - Ctrl+C to stop\n"
 
         if @options.include_self || Config.include_self
-          
           opts = OpenStruct.new(
             port: @port,
             server: Config.target_host || 'localhost',

--- a/lib/hunter/commands/list.rb
+++ b/lib/hunter/commands/list.rb
@@ -45,7 +45,8 @@ module Hunter
               n.ip,
               n.groups.any? ? n.groups.join("|") : "|",
               n.label,
-              n.presets.to_json
+              n.presets.to_json,
+              n.mac
             ]
             puts a.join("\t")
           end
@@ -58,14 +59,14 @@ module Hunter
               t = Table.new
               case @options.buffer
               when true
-                t.headers('ID', 'Hostname', 'IP', 'Presets')
+                t.headers('ID', 'Hostname', 'IP', 'MAC', 'Presets')
                 nodes.each do |node|
-                  t.row(node.id, node.hostname, node.ip, node.pretty_presets)
+                  t.row(node.id, node.hostname, node.ip, node.mac, node.pretty_presets)
                 end
               when false
-                t.headers('ID', 'Label', 'Hostname', 'IP')
+                t.headers('ID', 'Label', 'Hostname', 'IP', 'MAC')
                 nodes.each do |node|
-                  t.row(node.id, node.label, node.hostname, node.ip)
+                  t.row(node.id, node.label, node.hostname, node.ip, node.mac)
                 end
               end
 
@@ -77,14 +78,14 @@ module Hunter
 
             case @options.buffer
             when true
-              t.headers('ID', 'Hostname', 'IP', 'Groups', 'Presets')
+              t.headers('ID', 'Hostname', 'IP', 'MAC', 'Groups', 'Presets')
               list.nodes.each do |node|
-                t.row(node.id, node.hostname, node.ip, node.groups&.join(", "), node.pretty_presets)
+                t.row(node.id, node.hostname, node.ip, node.mac, node.groups&.join(", "), node.pretty_presets)
               end
             when false
-              t.headers('ID', 'Label', 'Hostname', 'IP', 'Groups')
+              t.headers('ID', 'Label', 'Hostname', 'IP', 'MAC', 'Groups')
               list.nodes.each do |node|
-                t.row(node.id, node.label, node.hostname, node.ip, node.groups&.join(", "))
+                t.row(node.id, node.label, node.hostname, node.ip, node.mac, node.groups&.join(", "))
               end
             end
             t.emit

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -118,7 +118,7 @@ module Hunter
           label: @options.label,
           prefix: @options.prefix,
           groups: @options.groups,
-          auth_key: auth_key
+          auth_key: auth_key,
           mac: mac
         }
       end

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -108,7 +108,7 @@ module Hunter
         hostname = Socket.gethostname
 
         # Find MAC of the relevant interface
-        interface = `ip route get #{Config.target_host} | head -n1 | awk '{print $5}'`
+        interface = `ip route get #{Config.target_host} | head -n1 | awk '{print $5}'`.chomp
         mac = `ip addr show #{interface} | grep link/ether | awk '{print $2}'`.chomp
 
         {

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -107,6 +107,10 @@ module Hunter
 
         hostname = Socket.gethostname
 
+        # Find MAC of the relevant interface
+        interface = `ip route get #{Config.target_host} | head -n1 | awk '{print $5}'`
+        mac = `ip addr show #{interface} | grep link/ether | awk '{print $2}'`.chomp
+
         {
           hostid: hostid,
           hostname: hostname,
@@ -115,6 +119,7 @@ module Hunter
           prefix: @options.prefix,
           groups: @options.groups,
           auth_key: auth_key
+          mac: mac
         }
       end
     end

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -108,7 +108,7 @@ module Hunter
         hostname = Socket.gethostname
 
         # Find MAC of the relevant interface
-        interface = `ip route get #{Config.target_host} | head -n1 | awk '{print $5}'`.chomp
+        interface = `ip route get 8.8.8.8 | head -n1 | awk '{print $5}'`.chomp
         mac = `ip addr show #{interface} | grep link/ether | awk '{print $2}'`.chomp
 
         {

--- a/lib/hunter/node.rb
+++ b/lib/hunter/node.rb
@@ -63,12 +63,7 @@ module Hunter
       @content = content
       @groups = groups || []
       @presets = presets.reject { |k,v| v.nil? || v.empty? }
-      if mac.nil?
-        `ping #{ip} -c 1`
-        @mac = `ip neigh | grep #{ip} | awk '{print $5}'`.chomp
-      else
-        @mac = mac
-      end
+      @mac = mac
     end
 
     private

--- a/lib/hunter/node.rb
+++ b/lib/hunter/node.rb
@@ -35,7 +35,8 @@ module Hunter
         'ip' => ip,
         'content' => content,
         'groups' => groups,
-        'presets' => presets
+        'presets' => presets,
+        'mac' => mac
       }
     end
 
@@ -51,10 +52,10 @@ module Hunter
       presets.map { |k,v| "#{k}: '#{v}'" }.join("\n")
     end
 
-    attr_reader :id, :ip, :content, :groups, :hostname, :presets
+    attr_reader :id, :ip, :content, :groups, :hostname, :presets, :mac
     attr_accessor :label
 
-    def initialize(id:, hostname:, label: nil, ip:, content:, groups: [], presets: {})
+    def initialize(id:, hostname:, label: nil, ip:, content:, groups: [], presets: {}, mac: nil)
       @id = id
       @hostname = hostname
       @label = label
@@ -62,6 +63,12 @@ module Hunter
       @content = content
       @groups = groups || []
       @presets = presets.reject { |k,v| v.nil? || v.empty? }
+      if mac.nil?
+        `ping #{ip} -c 1`
+        @mac = `ip neigh | grep #{ip} | awk '{print $5}'`.chomp
+      else
+        @mac = mac
+      end
     end
 
     private

--- a/lib/hunter/node_list.rb
+++ b/lib/hunter/node_list.rb
@@ -111,7 +111,8 @@ module Hunter
             ip: node['ip'],
             content: node['content'],
             groups: node['groups'],
-            presets: node['presets']
+            presets: node['presets'],
+            mac: node['mac']
           )
         end
       end


### PR DESCRIPTION
This PR enables Hunter clients to directly send the MAC address of the relevant interface to the server running `hunt`, and this will be stored alongside the other node details and shown when listing nodes (both in the buffer and parsed node lists).