### PR TITLE
List unification

### DIFF
--- a/lib/hunter/commands/list.rb
+++ b/lib/hunter/commands/list.rb
@@ -55,39 +55,12 @@ module Hunter
           case @options.by_group
           when true
             list.nodes(by_group: true).each do |group, nodes|
-              t = Table.new
-              case @options.buffer
-              when true
-                t.headers('ID', 'Hostname', 'IP', 'Presets')
-                nodes.each do |node|
-                  t.row(node.id, node.hostname, node.ip, node.pretty_presets)
-                end
-              when false
-                t.headers('ID', 'Label', 'Hostname', 'IP')
-                nodes.each do |node|
-                  t.row(node.id, node.label, node.hostname, node.ip)
-                end
-              end
-
               puts "Group '#{group}':"
-              t.emit
+              
+              Table.from_nodes(list.nodes, buffer: @options.buffer).emit
             end
           when false
-            t = Table.new
-
-            case @options.buffer
-            when true
-              t.headers('ID', 'Hostname', 'IP', 'Groups', 'Presets')
-              list.nodes.each do |node|
-                t.row(node.id, node.hostname, node.ip, node.groups&.join(", "), node.pretty_presets)
-              end
-            when false
-              t.headers('ID', 'Label', 'Hostname', 'IP', 'Groups')
-              list.nodes.each do |node|
-                t.row(node.id, node.label, node.hostname, node.ip, node.groups&.join(", "))
-              end
-            end
-            t.emit
+            Table.from_nodes(nodes, buffer: @options.buffer).emit
           end
         end
       end

--- a/lib/hunter/commands/modify_groups.rb
+++ b/lib/hunter/commands/modify_groups.rb
@@ -57,12 +57,7 @@ module Hunter
 
         puts "Node(s) updated successfully:"
         
-        t = Table.new
-        t.headers('ID', 'Label', 'Hostname', 'Groups')
-        nodes.each do |n|
-          t.row(n.id, n.label, n.hostname, n.groups.join(", "))
-        end
-        t.emit
+        Table.from_nodes(nodes, buffer: buffer).emit
       end
     end
   end

--- a/lib/hunter/commands/parse.rb
+++ b/lib/hunter/commands/parse.rb
@@ -61,15 +61,10 @@ module Hunter
         @parsed.nodes.concat(final)
         @buffer.delete(final)
 
-        if @parsed.save && @buffer.save
+        if final.any? && @parsed.save && @buffer.save
           puts "Nodes saved to parsed node list:"
 
-          t = Table.new
-          t.headers('ID', 'Label', 'Hostname', 'IP', 'Groups')
-          final.each do |n|
-            t.row(n.id, n.label, n.hostname, n.ip, n.groups&.join(", "))
-          end
-          t.emit
+          Table.from_nodes(final).emit
         end
       end
 

--- a/lib/hunter/commands/remove_node.rb
+++ b/lib/hunter/commands/remove_node.rb
@@ -50,12 +50,7 @@ module Hunter
         if list.delete(nodes) && list.save
           puts "The following nodes have successfully been removed from list '#{list.name}'"
 
-          t = Table.new
-          t.headers('ID', 'Label', 'Hostname', 'Groups')
-          nodes.each do |n|
-            t.row(n.id, n.label, n.hostname, n.groups.join(", "))
-          end
-          t.emit
+          Table.from_nodes(nodes, buffer: buffer).emit
         end
       end
     end

--- a/lib/hunter/commands/show.rb
+++ b/lib/hunter/commands/show.rb
@@ -31,13 +31,13 @@ module Hunter
   module Commands
     class Show < Command
       def run
-        @buffer = @options.buffer
-        list_file = @buffer ? Config.node_buffer : Config.node_list
+        buffer = @options.buffer
+        list_file = buffer ? Config.node_buffer : Config.node_list
         list = NodeList.load(list_file)
 
-        node = list.find(search_field(@buffer) => args[0])
+        node = list.find(search_field(buffer) => args[0])
 
-        raise "Node with #{search_field(@buffer)} '#{args[0]}' doesn't exist in list '#{list.name}'" if !node
+        raise "Node with #{search_field(buffer)} '#{args[0]}' doesn't exist in list '#{list.name}'" if !node
 
         if @options.plain
           a = [
@@ -48,11 +48,7 @@ module Hunter
           ]
           puts a.join("\t")
         else
-          t = Table.new
-          t.headers('ID', 'Label', 'Hostname', 'IP', 'Groups')
-          t.row(node.id, node.label, node.hostname, node.ip, node.groups.join(", "))
-          t.emit
-          puts node.content
+          Table.from_nodes([node], buffer: buffer).emit
         end
       end
     end

--- a/lib/hunter/node.rb
+++ b/lib/hunter/node.rb
@@ -58,9 +58,9 @@ module Hunter
     def to_table_row(buffer: false)
       case buffer
       when true
-        [id, hostname, ip, pretty_groups, pretty_presets]
+        [Paint[id, :cyan], hostname, ip, pretty_groups, pretty_presets]
       when false
-        [id, label, hostname, ip, pretty_groups]
+        [Paint[id, :cyan], label, hostname, ip, pretty_groups]
       end
     end
 

--- a/lib/hunter/node.rb
+++ b/lib/hunter/node.rb
@@ -51,6 +51,19 @@ module Hunter
       presets.map { |k,v| "#{k}: '#{v}'" }.join("\n")
     end
 
+    def pretty_groups
+      groups.join(", ")
+    end
+
+    def to_table_row(buffer: false)
+      case buffer
+      when true
+        [id, hostname, ip, pretty_groups, pretty_presets]
+      when false
+        [id, label, hostname, ip, pretty_groups]
+      end
+    end
+
     def groups
       @groups.sort
     end

--- a/lib/hunter/table.rb
+++ b/lib/hunter/table.rb
@@ -45,6 +45,21 @@ module Hunter
       )
     end
 
+    def self.from_nodes(nodes, buffer: false)
+      new.tap do |table|
+        headers = case buffer
+                  when true
+                    ['ID', 'Hostname', 'IP', 'Groups', 'Presets']
+                  when false
+                    ['ID', 'Label', 'Hostname', 'IP', 'Groups']
+                  end
+        rows = nodes.map { |n| n.to_table_row(buffer: buffer) }
+
+        table.headers(*headers)
+        table.rows(*rows)
+      end
+    end
+
     def padding(*pads)
       @padding = pads.length == 1 ? pads.first : pads
     end


### PR DESCRIPTION
This PR aims to be more uniform in how we print nodes in a tabular format.

A new class method has been added to the `Table` class, `::from_nodes`, to return a new `Table` object with rows created from a given `nodes` argument. The headers/rows used differ based on whether or not the nodes being listed are stored in the buffer or the parsed list.

A new instance method has been added to the `Node` class, `#to_table_row`, to return an array containing data to be used in the `Table::from_nodes` method. Again, the data returned depends on the buffer/parsed conditional.

When printing buffer nodes, the following data is shown:

```
┌──────────┬─────────────┬───────────┬───────────┬──────────────────┐
│ ID       │ Hostname    │ IP        │ Groups    │ Presets          │
├──────────┼─────────────┼───────────┼───────────┼──────────────────┤
│ 007f0101 │ jack-alces1 │ 127.0.0.1 │ testgroup │ label: 'cnode01' │
└──────────┴─────────────┴───────────┴───────────┴──────────────────┘
```

When printing parsed nodes, the following data is shown:

```
┌──────────┬─────────┬─────────────┬───────────┬───────────┐
│ ID       │ Label   │ Hostname    │ IP        │ Groups    │
├──────────┼─────────┼─────────────┼───────────┼───────────┤
│ 007f0101 │ cnode01 │ jack-alces1 │ 127.0.0.1 │ testgroup │
└──────────┴─────────┴─────────────┴───────────┴───────────┘
```

Resolves #51 when merged.