### PR TITLE
Store nodes in individual files

### DIFF
--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -158,7 +158,8 @@ module Hunter
           presets: {
             label: data["label"],
             prefix: data["prefix"]
-          }
+          },
+          filepath: File.join(Config.node_buffer, data["hostid"])
         )
 
         puts <<~EOF

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -149,6 +149,9 @@ module Hunter
       end
 
       def process_packet(data:)
+        buffer = NodeList.load(Config.node_buffer)
+        parsed = NodeList.load(Config.node_list)
+
         node = Node.new(
           id: data["hostid"],
           hostname: data["hostname"],
@@ -159,7 +162,7 @@ module Hunter
             label: data["label"],
             prefix: data["prefix"]
           },
-          filepath: File.join(Config.node_buffer, data["hostid"])
+          node_list: buffer
         )
 
         puts <<~EOF
@@ -169,9 +172,6 @@ module Hunter
         IP: #{node.ip}
 
         EOF
-
-        buffer = NodeList.load(Config.node_buffer)
-        parsed = NodeList.load(Config.node_list)
 
         if @options.allow_existing || Config.allow_existing
           buffer.nodes.delete_if { |n| n.id == node.id }

--- a/lib/hunter/commands/list.rb
+++ b/lib/hunter/commands/list.rb
@@ -60,7 +60,7 @@ module Hunter
               Table.from_nodes(list.nodes, buffer: @options.buffer).emit
             end
           when false
-            Table.from_nodes(nodes, buffer: @options.buffer).emit
+            Table.from_nodes(list.nodes, buffer: @options.buffer).emit
           end
         end
       end

--- a/lib/hunter/commands/parse.rb
+++ b/lib/hunter/commands/parse.rb
@@ -58,6 +58,10 @@ module Hunter
 
         existing = @parsed.nodes.select { |old| final.any? { |n| old.id == n.id } }
         @parsed.delete(existing)
+        final.each do |node|
+          node.delete_source
+          node.filepath = File.join(Config.node_list, node.id)
+        end
         @parsed.nodes.concat(final)
         @buffer.delete(final)
 

--- a/lib/hunter/commands/parse.rb
+++ b/lib/hunter/commands/parse.rb
@@ -59,11 +59,10 @@ module Hunter
         existing = @parsed.nodes.select { |old| final.any? { |n| old.id == n.id } }
         @parsed.delete(existing)
         final.each do |node|
-          node.delete_source
+          @buffer.delete([node])
           node.filepath = File.join(Config.node_list, node.id)
         end
         @parsed.nodes.concat(final)
-        @buffer.delete(final)
 
         if final.any? && @parsed.save && @buffer.save
           puts "Nodes saved to parsed node list:"

--- a/lib/hunter/commands/parse.rb
+++ b/lib/hunter/commands/parse.rb
@@ -60,7 +60,7 @@ module Hunter
         @parsed.delete(existing)
         final.each do |node|
           @buffer.delete([node])
-          node.filepath = File.join(Config.node_list, node.id)
+          node.node_list = @parsed
         end
         @parsed.nodes.concat(final)
 

--- a/lib/hunter/config.rb
+++ b/lib/hunter/config.rb
@@ -78,11 +78,11 @@ module Hunter
       end
 
       def node_buffer
-        var_file('buffer.yaml')
+        var_dir('buffer')
       end
 
       def node_list
-        var_file('parsed.yaml')
+        var_dir('parsed')
       end
 
       def save_data
@@ -133,6 +133,12 @@ module Hunter
         FileUtils.mkdir_p(parent_dir)
         file = File.join(root, 'var', *a)
         FileUtils.touch(file).first
+      end
+
+      def var_dir(*a)
+        dir = File.join(root, 'var', *a)
+        FileUtils.mkdir_p(dir)
+        dir
       end
 
       def xdg_config

--- a/lib/hunter/node.rb
+++ b/lib/hunter/node.rb
@@ -68,10 +68,18 @@ module Hunter
       @groups.sort
     end
 
-    attr_reader :id, :ip, :content, :hostname, :presets
-    attr_accessor :label
+    def save
+      File.open(filepath, 'w+') { |f| f.write(YAML.dump(to_h)) }
+    end
 
-    def initialize(id:, hostname:, label: nil, ip:, content:, groups: [], presets: {})
+    def delete_source
+      File.delete(filepath)
+    end
+
+    attr_reader :id, :ip, :content, :hostname, :presets
+    attr_accessor :label, :filepath
+
+    def initialize(id:, hostname:, label: nil, ip:, content:, groups: [], presets: {}, filepath:)
       @id = id
       @hostname = hostname
       @label = label
@@ -79,6 +87,7 @@ module Hunter
       @content = content
       @groups = groups || []
       @presets = presets.reject { |k,v| v.nil? || v.empty? }
+      @filepath = filepath
     end
   end
 end

--- a/lib/hunter/node.rb
+++ b/lib/hunter/node.rb
@@ -68,6 +68,10 @@ module Hunter
       @groups.sort
     end
 
+    def filepath
+      File.join(node_list.dir, "#{id}.yaml") if node_list
+    end
+
     def save
       File.open(filepath, 'w+') { |f| f.write(YAML.dump(to_h)) }
     end
@@ -77,9 +81,9 @@ module Hunter
     end
 
     attr_reader :id, :ip, :content, :hostname, :presets
-    attr_accessor :label, :filepath
+    attr_accessor :label, :node_list
 
-    def initialize(id:, hostname:, label: nil, ip:, content:, groups: [], presets: {}, filepath:)
+    def initialize(id:, hostname:, label: nil, ip:, content:, groups: [], presets: {}, node_list: nil)
       @id = id
       @hostname = hostname
       @label = label
@@ -87,7 +91,7 @@ module Hunter
       @content = content
       @groups = groups || []
       @presets = presets.reject { |k,v| v.nil? || v.empty? }
-      @filepath = filepath
+      @node_list = node_list
     end
   end
 end

--- a/lib/hunter/node_list.rb
+++ b/lib/hunter/node_list.rb
@@ -101,24 +101,19 @@ module Hunter
 
     def initialize(dir)
       @dir = dir
-      @nodes = [].tap do |ns|
-        list = [].tap do |l|
-          Dir[File.join(dir, "*")].each do |file|
-            l << YAML.load_file(file).merge({"filepath" => file})
-          end
-        end
-        list.each do |node|
-          ns << Node.new(
-            id: node['id'],
-            hostname: node['hostname'],
-            label: node['label'],
-            ip: node['ip'],
-            content: node['content'],
-            groups: node['groups'],
-            presets: node['presets'],
-            filepath: node['filepath']
-          )
-        end
+      @nodes = Dir[File.join(dir, "*")].map do |file|
+        data = YAML.load_file(file)
+        
+        Node.new(
+          id: data['id'],
+          hostname: data['hostname'],
+          label: data['label'],
+          ip: data['ip'],
+          content: data['content'],
+          groups: data['groups'],
+          presets: data['presets'],
+          node_list: self
+        )
       end
     end
   end


### PR DESCRIPTION
This PR moves the data for each node into its own file, stored in the relevant directory (`var/buffer` or `var/parsed`). A new `filepath` attribute was added to `Node` to accommodate this. Each file is named using the hostid of the origin node.

A typo in the `list` command was also fixed.