### PR TITLE
Automatiically parse nodes

### DIFF
--- a/lib/hunter/cli.rb
+++ b/lib/hunter/cli.rb
@@ -64,6 +64,7 @@ module Hunter
       c.slop.string '--port', 'Override port'
       c.slop.bool '--include-self', 'Immediately try to send payload to self'
       c.slop.string "--auth", "Override default authentication key"
+      c.slop.string '--auto-parse', 'Automatically parse nodes matching this regex'
       c.action Commands, :hunt
     end
 

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -176,6 +176,7 @@ module Hunter
 
         buffer = NodeList.load(Config.node_buffer)
         parsed = NodeList.load(Config.node_list)
+        dest = buffer
         if node.hostname.match(Regexp.new(@auto_regex))
           dest = parsed
           node.label = node.presets[:label] || node.hostname.split(".").first

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -183,7 +183,7 @@ module Hunter
         if @options.allow_existing || Config.allow_existing
           dest.nodes.delete_if { |n| n.id == node.id }
           dest.nodes << node
-          puts "Node added to #{File.basename(dest.filepath)} node list"
+          puts "Node added to #{dest.name} node list"
         else
           if buffer.include_id?(node.id)
             puts "ID already exists in buffer"
@@ -191,7 +191,7 @@ module Hunter
             puts "ID already exists in parsed node list"
           else
             dest.nodes << node
-            puts "Node added to #{File.basename(dest.filepath)} node list"
+            puts "Node added to #{dest.name} node list"
           end
         end
 

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -174,8 +174,6 @@ module Hunter
 
         EOF
 
-        buffer = NodeList.load(Config.node_buffer)
-        parsed = NodeList.load(Config.node_list)
         dest = buffer
         if node.hostname.match(Regexp.new(@auto_regex))
           dest = parsed

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -162,8 +162,7 @@ module Hunter
           presets: {
             label: data["label"],
             prefix: data["prefix"]
-          },
-          node_list: buffer
+          }
         )
 
         puts <<~EOF
@@ -179,6 +178,8 @@ module Hunter
           dest = parsed
           node.label = node.presets[:label] || node.hostname.split(".").first
         end
+
+        node.node_list = dest
 
         if @options.allow_existing || Config.allow_existing
           dest.nodes.delete_if { |n| n.id == node.id }

--- a/lib/hunter/commands/remove_node.rb
+++ b/lib/hunter/commands/remove_node.rb
@@ -44,7 +44,7 @@ module Hunter
           when false
             [list.find(search_field(buffer) =>  args[0])]
           end
-        
+
         raise "No #{search_field(buffer)}s in list '#{list.name}' match pattern '#{args[0]}'" unless nodes&.any?
 
         if list.delete(nodes) && list.save


### PR DESCRIPTION
This PR introduces a new option for the `hunt` command. If `--auto-parse EXPR` is used, hunted nodes with names matching the regex `EXPR` will skip the buffer and be added straight to the parsed node list, with the label being either the preset label (if it exists), or the first part of the node's hostname.

NB When a node is hunted, it is should print `Node added to the <buffer/parsed> node list`. The current implementation is made with the new node-file implementation in mind, and as a side effect it currently prints `buffer.yaml` and `parsed.yaml` respectively, instead of just `buffer` and `parsed`, if the nodes aren't being stored in individual files.