### PR TITLE
Fix error with hunter logging

### DIFF
--- a/bin/hunter
+++ b/bin/hunter
@@ -29,6 +29,7 @@ begin
   lib_dir = File.expand_path(File.join(__FILE__, '../../lib'))
   $LOAD_PATH.unshift(lib_dir)
   ENV['BUNDLE_GEMFILE'] ||= File.join(__FILE__, '../../Gemfile')
+  $stdout.sync = true
 
   require 'rubygems'
   require 'bundler'

--- a/bin/start
+++ b/bin/start
@@ -15,4 +15,4 @@ mkdir -p $install_dir/var/log
 
 exec \
   env flight_HUNTER_pidfile=$1 \
-  "${flight_ROOT}"/bin/flexec ruby $install_dir/bin/hunter autorun |& tee $install_dir/var/log/log.txt
+  "${flight_ROOT}"/bin/flexec ruby $install_dir/bin/hunter autorun |& tee -a $install_dir/var/log/log.txt


### PR DESCRIPTION
When run through Flight Service, the output of `hunt` is intended to be saved to a log file. This seemed to not be working, and it turns out this was because output on stdout is automatically buffered when not being written to a terminal, so the full log would only be written after stopping the `hunt` process. This PR ensures that stdout is always written to the file without buffering.

The logging process will now also avoid overwriting the previous log, instead appending its own output to the log file if it already exists.