### PR TITLE
README refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,17 @@ Flight Hunter has some required configuration based on the environment it is bei
 - `allow_existing` - Overwrite existing nodes when hunting/parsing a node that already exists
 - `auth_key` - Specify an authentication key allowing only nodes with a matching key to connect
 - `broadcast_address` - Specify an IP address range to use when using `send`'s broadcast mode.
+- `profile_command` - Specify the path to your Flight Profile executable (if it exists).
 
 Each of the above config keys can be overwritten at all levels by an environment variable of the form `flight_HUNTER_*key*`.
 
 Flight Hunter uses a PID file to track the `hunt` server process. By default, this PID file is created at `/tmp/hunter.pid`. The filepath used can be changed by setting the environment varaible `flight_HUNTER_pidfile`.
 
-
 ## Operation
 
 A brief usage guide is given below. See the `help` command for further details and information about other commands.
 
-Run the Hunter listening server with `hunt`. By default, nodes that already exist in the Hunter nodelist are ignored. Override existing nodes with `hunt --allow-existing`. The server can immediately `send` to itself with `--include-self`.
+Run the Hunter listening server with `hunt`. By default, nodes that already exist in the Hunter nodelist are ignored. Override existing nodes with `hunt --allow-existing`. The server can immediately `send` to itself with `--include-self`. The `--auto-parse` argument allows the server to attempt to automatically parse nodes whose hostname matches the given regular expression.
 
 Run the Hunter payload transmitter with `send`. The system's hostid, IP, hostname, and a default chunk of diagnostic data will be sent to the Hunter server running at the configured IP/port. The system hostname and data content can be overwritten via command line options. You may also provide a label or a prefix to use for the node's label when being parsed by the host machine.
 
@@ -61,7 +61,7 @@ The `send` command will, by default, attempt to establish a TCP connection with 
 192.168.255.255
 ```
 
-and so on. CIDR format IP ranges (e.g. `192.168.0.0/16`) are *not* currently supported. Please be aware that, by default the maximum transmission unit for a UDP broadcast is 1500 bytes. Not all kernels support fragmentation for UDP broadcasts, so please be aware of your kernel's capabilities (and your payload size) before using this transmission mode.
+and so on. CIDR format IP ranges (e.g. `192.168.0.0/16`) are *not* currently supported. Please be aware that, by default, the maximum transmission unit for a UDP broadcast is 1500 bytes. Not all kernels support fragmentation for UDP broadcasts, so please be aware of your kernel's capabilities (and your payload size) before using this transmission mode.
 
 See all nodes in the node list with `list`.
 

--- a/etc/config.yml.ex
+++ b/etc/config.yml.ex
@@ -1,27 +1,31 @@
 ---
-# Host to send data to when running client
+# Host to send data to when running client (optional)
 # target_host:
 #
-# Port to listen/send over. This must match on both server and client.
+# Port to listen/send over. This must match on both server and client. (required)
 # port:
 #
-# Mode to use when autorun
+# Mode to use when autorun (optional)
 # autorun_mode:
 #
-# Automatically include self when hunting
+# Automatically include self when hunting (optional)
 # include_self: false
 #
-# Command to use to generate content
+# Command to use to generate content (optional)
 # content_command:
 #
-# Allow existing nodes when hunting
+# Allow existing nodes when hunting (optional)
 # allow_existing: false
 #
-# Key used to authenticate data
+# Key used to authenticate data (required)
 # auth_key: flight-hunter
 #
-# Broadcast address to use when sending via a UDP broadcast
+# Broadcast address to use when sending via a UDP broadcast (optional)
 # broadcast_address: 127.0.255.255
 #
-# Command used to run the Flight Profile executable
+# Command used to run the Flight Profile executable (optional)
 # profile_command:
+#
+# Attempt to automatically parse nodes when hunted, if they match the given
+# regular expression (optional)
+# auto_parse: /expression/

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -39,7 +39,7 @@ module Hunter
       def run
         @port = @options.port || Config.port
         @auth_key = @options.auth || Config.auth_key
-        @auto_regex = @options.auto_parse || ".^"
+        @auto_regex = @options.auto_parse || Config.auto_parse || ".^"
         raise "No port provided!" if !@port
 
         pidpath = ENV['flight_HUNTER_pidfile']

--- a/lib/hunter/config.rb
+++ b/lib/hunter/config.rb
@@ -77,6 +77,10 @@ module Hunter
         ENV['flight_HUNTER_auth_key'] || data.fetch(:auth_key)
       end
 
+      def auto_parse
+        ENV['flight_HUNTER_auto_parse'] || data.fetch(:auto_parse)
+      end
+
       def profile_command
         command =
           ENV['flight_HUNTER_profile_command'] ||


### PR DESCRIPTION
The README was missing a few details from recent PRs; this PR brings it a tad more up to scratch. It also introduces being able to set the auto-parse option for `hunt` as a config key, as otherwise it wouldn't be available to users running `autorun` (and therefore, anyone using the Flight Service implementation).