### PR TITLE
Auto apply a profile

### DIFF
--- a/etc/config.yml.ex
+++ b/etc/config.yml.ex
@@ -29,3 +29,12 @@
 # Attempt to automatically parse nodes when hunted, if they match the given
 # regular expression (optional)
 # auto_parse: /expression/
+#
+# Attempt to automatically trigger Flight Profile for nodes that have been
+# picked up by the `auto_parse` functionality. Must be a set of key/value
+# pairs, where the key is a regular expression to match the node's label
+# against and the value is the name of an identity existing within your
+# given Flight Profile installation
+# auto_apply:
+#   exp1: identity1
+#   exp2: identity2

--- a/lib/hunter/cli.rb
+++ b/lib/hunter/cli.rb
@@ -63,8 +63,9 @@ module Hunter
       c.slop.bool '--allow-existing', 'Allow replacement of existing entries'
       c.slop.string '--port', 'Override port'
       c.slop.bool '--include-self', 'Immediately try to send payload to self'
-      c.slop.string "--auth", "Override default authentication key"
+      c.slop.string '--auth', "Override default authentication key"
       c.slop.string '--auto-parse', 'Automatically parse nodes matching this regex'
+      c.slop.string '--auto-apply', 'YAML string to map parsed labels to Flight Profile identities'
       c.action Commands, :hunt
     end
 

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -31,6 +31,7 @@ require_relative '../command'
 require_relative '../config'
 require_relative '../node'
 require_relative '../node_list'
+require_relative '../profile_cli'
 
 
 module Hunter
@@ -197,6 +198,10 @@ module Hunter
         end
 
         dest.save
+
+        if @options.auto_parse
+          ProfileCLI.apply(node.label, "all-in-one", force: true)
+        end
       end
 
       private

--- a/lib/hunter/config.rb
+++ b/lib/hunter/config.rb
@@ -81,6 +81,10 @@ module Hunter
         ENV['flight_HUNTER_auto_parse'] || data.fetch(:auto_parse)
       end
 
+      def auto_apply
+        ENV['flight_HUNTER_auto_apply'] || data.fetch(:auto_apply)
+      end
+
       def profile_command
         command =
           ENV['flight_HUNTER_profile_command'] ||

--- a/lib/hunter/profile_cli.rb
+++ b/lib/hunter/profile_cli.rb
@@ -32,7 +32,7 @@ require 'fileutils'
 module Hunter
   class ProfileCLI
     class << self
-      def apply(node, identity, force: false)
+      def apply(node, identity)
         args = [
           "apply",
           node,
@@ -42,7 +42,8 @@ module Hunter
         cmd.run.tap do |result|
           if result.success?
             return result.stdout
-          else puts "ERROR"
+          else
+            puts "ERROR"
           end
         end
       end

--- a/lib/hunter/profile_cli.rb
+++ b/lib/hunter/profile_cli.rb
@@ -32,6 +32,20 @@ require 'fileutils'
 module Hunter
   class ProfileCLI
     class << self
+      def apply(node, identity, force: false)
+        args = [
+          "apply",
+          node,
+          identity
+        ]
+        cmd = new(*flight_profile, *args)
+        cmd.run.tap do |result|
+          if result.success?
+            return result.stdout
+          else puts "ERROR"
+          end
+        end
+      end
 
       private
 


### PR DESCRIPTION
NB: This PR is based on changes made in #58 , which should be reviewed/merged _before_ this PR.

This PR introduces changes to the `hunt` command that allows it to attempt to trigger Flight Profile if the node's label matches a given regular expression.

A new config option has been added, `auto_apply`, which allows the user to define a set of rules containing regular expressions and Flight Profile identity names. The rules are defined as follows:
```yaml
auto_apply:
  $chead: login
  cnode0[1-5]^: compute1
  cnode[6-10]^: compute2
```

When a node has been automatically parsed (see #56 ), its label is then checked against the keys of the `auto_apply` rules. The first key that, as a regular expression, matches the node's label, is picked as the auto-apply rule. The value of the chosen key is interpreted as an identity that presumably exists in the user's given Flight Profile installation, and Flight Profile is subprocessed with the node's label and chosen identity. Flight Profile may then use the node's label to call Hunter and fetch its hostname, and continue applying as usual.