### PR TITLE
Only auto-apply when option is used

### DIFF
--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -211,7 +211,7 @@ module Hunter
 
         # Have to do this last because it depends on the parsed list being up
         # to date
-        apply_to_node(node) if @options.auto_apply && @added
+        apply_to_node(node) if @options.auto_apply && @added && dest == parsed
       end
 
       private

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -211,7 +211,7 @@ module Hunter
 
         # Have to do this last because it depends on the parsed list being up
         # to date
-        apply_to_node(node) if @added
+        apply_to_node(node) if @options.auto_apply && @added
       end
 
       private


### PR DESCRIPTION
This PR fixes a bug in which a node would always be applied when hunted regardless of the status of `--auto-apply`.