### PR TITLE
Auto-apply on parse

### DIFF
--- a/lib/hunter/cli.rb
+++ b/lib/hunter/cli.rb
@@ -65,7 +65,6 @@ module Hunter
       c.slop.bool '--include-self', 'Immediately try to send payload to self'
       c.slop.string '--auth', "Override default authentication key"
       c.slop.string '--auto-parse', 'Automatically parse nodes matching this regex'
-      c.slop.string '--auto-apply', 'YAML string to map parsed labels to Flight Profile identities'
       c.action Commands, :hunt
     end
 

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -41,27 +41,12 @@ module Hunter
         @port = @options.port || Config.port
         @auth_key = @options.auth || Config.auth_key
         @auto_parse = @options.auto_parse || Config.auto_parse || ".^"
-        @auto_apply = begin
-                        cli = @options.auto_apply
-                        cli ? YAML.load(cli) : {}
-                      rescue Psych::SyntaxError
-                        raise "Invalid YAML passed via `--auto-apply`"
-                      end
-        @auto_apply ||= Config.auto_apply
+        # Fetch auto_apply to raise an error if it's invalid
+        Config.auto_apply
 
         # Validate auto-parse expression
         unless valid_regex?(@auto_parse)
           raise "Invalid regular expression passed to `auto_parse` option"
-        end
-
-        # Validate auto-apply expression
-        raise "Malformed hash passed to `auto_apply`" unless @auto_apply.is_a?(Hash)
-        bad_apply_exps = @auto_apply.map { |k,v| !valid_regex?(k) }
-        if bad_apply_exps.any?
-          raise <<~OUT.chomp
-          The following regular expressions passed to `auto_apply` are invalid:
-          #{bad_apply_exps.join("\n")}
-          OUT
         end
 
         raise "No port provided!" if !@port
@@ -206,27 +191,23 @@ module Hunter
         node.node_list = dest
 
         if @options.allow_existing || Config.allow_existing
+          node.auto_apply = dest == parsed
           dest.nodes.delete_if { |n| n.id == node.id }
           dest.nodes << node
           puts "Node added to #{dest.name} node list"
-          @added = true
         else
           if buffer.include_id?(node.id)
             puts "ID already exists in buffer"
           elsif parsed.include_id?(node.id)
             puts "ID already exists in parsed node list"
           else
+            node.auto_apply = dest == parsed
             dest.nodes << node
             puts "Node added to #{dest.name} node list"
-            @added = true
           end
         end
 
         dest.save
-
-        # Have to do this last because it depends on the parsed list being up
-        # to date
-        apply_to_node(node) if @options.auto_apply && @added && dest == parsed
       end
 
       private
@@ -235,18 +216,6 @@ module Hunter
         Regexp.new(regex.to_s)
       rescue RegexpError => e
         false
-      end
-
-      def apply_to_node(node)
-        identity = @auto_apply.find { |rule, _| node.label.match(Regexp.new(rule)) }
-
-        return unless identity
-
-        puts <<~OUT.chomp
-        Node #{node.label} matches auto-apply rule '#{identity[0]}: #{identity[1]}'
-        OUT
-
-        ProfileCLI.apply(node.label, identity[1])
       end
 
       def valid_json?(str)

--- a/lib/hunter/commands/parse.rb
+++ b/lib/hunter/commands/parse.rb
@@ -37,6 +37,9 @@ module Hunter
         raise "No nodes in buffer" if @buffer.nodes.empty?
         @parsed = NodeList.load(Config.node_list)
 
+        # Load auto_apply rules list so we can check if it's valid
+        Config.auto_apply
+
         if @options.start && !/\A\d+\z/.match(@options.start)
           raise "Please provide a valid positive integer value for `--start`"
         end
@@ -61,6 +64,7 @@ module Hunter
         final.each do |node|
           @buffer.delete([node])
           node.node_list = @parsed
+          node.auto_apply = !Config.auto_apply.nil?
         end
         @parsed.nodes.concat(final)
 


### PR DESCRIPTION
This PR updates the auto-apply workflow to ensure it triggers every time we make a parse action. The logic for automatically applying to a node has been moved from the `hunt` command to the `Node` class. When we create a new node to add to the parsed list, we give it the `@auto_apply = true` attribute, signaling to the `Node#save` method that it ought to attempt to apply a Flight Profile identity to it.

The changes in this PR are a bit hacky, and if it turns out to be too hard to test quickly then we may wish to roll the changes back for this release and work on them a bit more in the next release.

Node lists and nodes don't understand the concept of `parse`; only being `saved` after they've been updated elsewhere. It may be a good idea to update the node list class later to have more concrete definitions of a buffer list and a parsed list, as the over-encapsulation of logic that we have right now is making features like this a little bit harder.