### PR TITLE
Fix auto-apply rules loading mishap

### DIFF
--- a/lib/hunter/cli.rb
+++ b/lib/hunter/cli.rb
@@ -65,7 +65,6 @@ module Hunter
       c.slop.bool '--include-self', 'Immediately try to send payload to self'
       c.slop.string '--auth', "Override default authentication key"
       c.slop.string '--auto-parse', 'Automatically parse nodes matching this regex'
-      c.slop.string '--auto-apply', 'YAML string to map parsed labels to Flight Profile identities'
       c.action Commands, :hunt
     end
 

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -41,14 +41,7 @@ module Hunter
         @port = @options.port || Config.port
         @auth_key = @options.auth || Config.auth_key
         @auto_parse = @options.auto_parse || Config.auto_parse || ".^"
-        @auto_apply = begin
-                        cli = @options.auto_apply
-                        cli ? YAML.load(cli) : nil
-                      rescue Psych::SyntaxError
-                        raise "Invalid YAML passed via `--auto-apply`"
-                      end
-        @auto_apply ||= Config.auto_apply
-        @auto_apply ||= {}
+        @auto_apply = Config.auto_apply || {}
 
         # Validate auto-parse expression
         unless valid_regex?(@auto_parse)

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -43,11 +43,12 @@ module Hunter
         @auto_parse = @options.auto_parse || Config.auto_parse || ".^"
         @auto_apply = begin
                         cli = @options.auto_apply
-                        cli ? YAML.load(cli) : {}
+                        cli ? YAML.load(cli) : nil
                       rescue Psych::SyntaxError
                         raise "Invalid YAML passed via `--auto-apply`"
                       end
         @auto_apply ||= Config.auto_apply
+        @auto_apply ||= {}
 
         # Validate auto-parse expression
         unless valid_regex?(@auto_parse)
@@ -226,7 +227,7 @@ module Hunter
 
         # Have to do this last because it depends on the parsed list being up
         # to date
-        apply_to_node(node) if @options.auto_apply && @added && dest == parsed
+        apply_to_node(node) if @added && dest == parsed
       end
 
       private

--- a/lib/hunter/version.rb
+++ b/lib/hunter/version.rb
@@ -25,5 +25,5 @@
 # https://github.com/openflighthpc/flight-hunter
 #==============================================================================
 module Hunter
-  VERSION = '0.3.2-rc2'
+  VERSION = '0.3.2-rc3'
 end


### PR DESCRIPTION
This PR introduces a change to the auto-apply loading process. Previously, Hunter allowed for auto-apply rules to be specified at runtime via the CLI. This introduced touch of malarkey with regards to validating the input, and occasionally it wasn't reading anything from the config file. You can no longer specify the rules at the command line, and it is always initialised to at least an empty hash if the config file has no rules specified.