### PR TITLE
Fix long delay on manual parse

### DIFF
--- a/lib/hunter/profile_cli.rb
+++ b/lib/hunter/profile_cli.rb
@@ -39,13 +39,11 @@ module Hunter
           identity
         ]
         cmd = new(*flight_profile, *args)
-        cmd.run.tap do |result|
-          if result.success?
-            return result.stdout
-          else
-            puts "ERROR"
-          end
+
+        pid = Process.fork do
+          cmd.run
         end
+        Process.detach(pid)
       end
 
       private


### PR DESCRIPTION
When manually parsing a node with `auto_apply` enabled, the terminal would stall for 30s (the timeout duration) before returning control to the user. I believe to have narrowed down the problem to `flight-subprocess` continuing to wait for the `apply` process to complete. `flight-subprocess` already forks out to `profile`, but with this PR `hunter` now also forks out to `flight-subprocess` to avoid having to wait for it to deem the apply command "done".