### PR TITLE
Add an option to retry sending

### DIFF
--- a/lib/hunter/cli.rb
+++ b/lib/hunter/cli.rb
@@ -161,7 +161,7 @@ module Hunter
       c.slop.array "--groups", "Specify a comma-separated list of groups for this node"
       c.slop.string "--label", "Specify a label to use for this node"
       c.slop.string "--prefix", "Specify a prefix to use for this node"
-      c.slop.float "--retry", "Specify a number of seconds, send will be re-attempted with this delay until successful.
+      c.slop.float "--retry", "Specify a number of seconds, send will be re-attempted at this interval until successful."
       c.action Commands, :send_payload
     end
   end

--- a/lib/hunter/cli.rb
+++ b/lib/hunter/cli.rb
@@ -161,6 +161,7 @@ module Hunter
       c.slop.array "--groups", "Specify a comma-separated list of groups for this node"
       c.slop.string "--label", "Specify a label to use for this node"
       c.slop.string "--prefix", "Specify a prefix to use for this node"
+      c.slop.float "--retry", "Specify a number of seconds, send will be re-attempted with this delay until successful.
       c.action Commands, :send_payload
     end
   end

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -66,13 +66,13 @@ module Hunter
 
           request.body = data.to_json
 
-          send_request(request)
+          send_request(http, request)
         end
       end
 
       private
 
-      def send_request(request)
+      def send_request(http, request)
         begin
           response = http.request(request)
           response.value
@@ -90,7 +90,7 @@ module Hunter
         if @options.retry
           puts msg
           sleep(@options.retry)
-          send_request(request)
+          send_request(http, request)
         else
           raise msg
         end


### PR DESCRIPTION
This PR introduces the `--retry` option to `send`, which takes a float (or integer) argument, such that the command:

`send --retry n`

will try and send again `n` seconds after the previous send failed, until it is successfully received. The reason for the send failing is printed to STDOUT instead of being thrown as an error. This allows `send` to be run before `hunt` if required.

NB The only edge case that exists for this command is entering a negative number for the time interval, which doesn't need to be handled by us because Ruby's `sleep` error message gives a perfectly fine error message for negative values.