### PR TITLE
Accept multiple node per remove-node command

### DIFF
--- a/lib/hunter/cli.rb
+++ b/lib/hunter/cli.rb
@@ -107,10 +107,11 @@ module Hunter
     end
 
     command 'remove-node' do |c|
-      cli_syntax(c, 'NODE')
-      c.summary = 'Remove node from parsed list by label'
+      cli_syntax(c, 'NODE[,NODE...]')
+      c.summary = 'Remove nodes from parsed list by label'
       c.slop.bool '--buffer', "Use node buffer list instead of parsed (use ID instead of label here)"
-      c.slop.bool '--name', "Specify node by regex on hostname instead of ID"
+      c.slop.bool '--regex', "Match all nodes with regex NODE"
+      c.slop.bool '--match-hostname', "Match against hostname instead of label (or ID)"
       c.action Commands, :remove_node
     end
 

--- a/lib/hunter/node_list.rb
+++ b/lib/hunter/node_list.rb
@@ -27,7 +27,6 @@
 
 module Hunter
   class NodeList
-
     class << self
       def load(dir)
         raise "Node directory #{dir} doesn't exist" unless File.directory?(dir)
@@ -55,6 +54,10 @@ module Hunter
     def delete(nodes)
       nodes.map(&:delete_source)
       @nodes = @nodes - nodes
+    end
+
+    def select(*args, **kwargs, &block)
+      nodes.select(*args, **kwargs, &block)
     end
 
     def match(regex)


### PR DESCRIPTION
This PR changes the `remove-node` command to accept a comma-separated list of search terms, instead of a single search term. The previous options to switch between buffer/parsed nodelist, match against hostname, and match with regex still exist, although the hostname option has been renamed.