### PR TITLE
Close client after trying to access it

### DIFF
--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -134,9 +134,9 @@ module Hunter
 
               unless headers["Content-Type"] == "application/json"
                 # invalid content type
+                puts "Malformed packet received from #{client.peeraddr[2]}"
                 client.puts "HTTP/1.1 415\r\n"
                 client.close
-                puts "Malformed packet received from #{client.peeraddr[2]}"
                 next
               end
 


### PR DESCRIPTION
This PR fixes a bug that arises when receiving a malformed packet on a TCP connection. We post the client's address to the logfile, but we try to do it _after_ closing the connection, which raises an error.