### PR TITLE
Retry Input Type Validation

### DIFF
--- a/lib/hunter/cli.rb
+++ b/lib/hunter/cli.rb
@@ -162,7 +162,7 @@ module Hunter
       c.slop.array "--groups", "Specify a comma-separated list of groups for this node"
       c.slop.string "--label", "Specify a label to use for this node"
       c.slop.string "--prefix", "Specify a prefix to use for this node"
-      c.slop.float "--retry-interval", "Specify a number of seconds, send will be re-attempted at this interval until successful."
+      c.slop.string "--retry-interval", "Specify a number of seconds, send will be re-attempted at this interval until successful."
       c.action Commands, :send_payload
     end
   end

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -66,7 +66,7 @@ module Hunter
 
           request.body = data.to_json
 
-          if send_request(http, request)&.code != '200' && retry_interval
+          while send_request(http, request)&.code != '200' && retry_interval
             sleep(retry_interval)
           end
         end

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -70,6 +70,8 @@ module Hunter
             response = send_request(http, request)
             if !retry_interval || response&.code == '200'
               break
+            elsif !retry_interval.is_a?(Numeric)
+              raise 'Invalid value for the --retry-interval option'
             end
             sleep(retry_interval.to_f)
           end

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -69,7 +69,7 @@ module Hunter
           if send_request(http, request)&.code != '200' && retry_interval
             begin
               sleep(retry_interval.to_f)
-            end while send_request(http, request)&.code == '200'
+            end while send_request(http, request)&.code != '200'
           end
         end
       end

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -79,7 +79,7 @@ module Hunter
       def retry_interval
         @retry_interval ||= begin
           ri = Config.retry_interval || @options.retry_interval
-          ri.nil? nil : max(1, ri.to_f)
+          ri.nil? nil : max(5.0, ri.to_f)
         end
       end
 

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -66,15 +66,12 @@ module Hunter
 
           request.body = data.to_json
 
-          loop do
-            response = send_request(http, request)
-            if !retry_interval || response&.code == '200'
-              break
-            elsif retry_interval.is_a?(Numeric)
-              sleep(retry_interval.to_f)
-            else
-              raise 'Invalid value for the --retry-interval option'
+          if send_request(http, request)&.code != '200' && retry_interval.is_a?(Numeric)
+            until send_request(http, request)&.code == '200'
+                sleep(retry_interval.to_f)
             end
+          elsif retry_interval
+            raise 'Invalid value for the --retry-interval option'
           end
         end
       end

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -79,9 +79,9 @@ module Hunter
           ri = Config.retry_interval || @options.retry_interval
           return nil unless ri
           if !ri.match(/^\d+(\.\d+)?$/)
-            puts "Warning! Invalid value detected for --retry_interval. It has now been set to " + [5.0, ri.to_f].max + "."
+            puts "Warning! Invalid value detected for --retry_interval. It has now been set to " + [5.0, ri.to_f].max.to_s + "."
           elsif ri.to_f < 5.0
-            puts "Warning! The value for --retry_interval is too small. It has now been set to " + [5.0, ri.to_f].max + "."
+            puts "Warning! The value for --retry_interval is too small. It has now been set to 5.0."
           end
           [5.0, ri.to_f].max
         end

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -66,7 +66,7 @@ module Hunter
 
           request.body = data.to_json
 
-          until send_request(http, request)&.code == '200' || !retry_interval
+          if send_request(http, request)&.code != '200' && retry_interval
             sleep(retry_interval)
           end
         end

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -68,12 +68,15 @@ module Hunter
 
           loop do
             response = send_request(http, request)
-            if !retry_interval || response&.code == '200'
+            if response&.code != '200'
+              if retry_interval.is_a?(Numeric)  
+                sleep(retry_interval.to_f)
+              else
+                raise 'Invalid value for the --retry-interval option'
+              end
+            else
               break
-            elsif !retry_interval.is_a?(Numeric)
-              raise 'Invalid value for the --retry-interval option'
             end
-            sleep(retry_interval.to_f)
           end
         end
       end

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -70,13 +70,11 @@ module Hunter
             response = send_request(http, request)
             if !retry_interval || response&.code == '200'
               break
+            elsif retry_interval.is_a?(Numeric)
+              sleep(retry_interval.to_f)
             else
-              if retry_interval.is_a?(Numeric)  
-                sleep(retry_interval.to_f)
-              else
-                raise 'Invalid value for the --retry-interval option'
-              end
-            else
+              raise 'Invalid value for the --retry-interval option'
+            end
           end
         end
       end

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -68,15 +68,15 @@ module Hunter
 
           loop do
             response = send_request(http, request)
-            if response&.code != '200'
+            if !retry_interval || response&.code == '200'
+              break
+            else
               if retry_interval.is_a?(Numeric)  
                 sleep(retry_interval.to_f)
               else
                 raise 'Invalid value for the --retry-interval option'
               end
             else
-              break
-            end
           end
         end
       end

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -79,9 +79,9 @@ module Hunter
           ri = Config.retry_interval || @options.retry_interval
           return nil unless ri
           if !ri.match(/^\d+(\.\d+)?$/)
-            puts "Warning! Invalid value detected for --retry_interval. It has now been set to " + [5.0, ri.to_f].max.to_s + "."
+            puts "Warning! Invalid value detected for --retry-interval. It has now been set to " + [5.0, ri.to_f].max.to_s + "."
           elsif ri.to_f < 5.0
-            puts "Warning! The value for --retry_interval is too small. It has now been set to 5.0."
+            puts "Warning! The value for --retry-interval is too small. It has now been set to 5.0."
           end
           [5.0, ri.to_f].max
         end


### PR DESCRIPTION
# Overview

This PR modifies the `SendPayload#retry_interval` method and the retry loop in `SendPayload#run` method to validate the user input for the `--retry-interval` option. It converts the invalid input to a reasonable valid value and also limits the minimum acceptable value. See the Example section below for the demonstration.

## Major Changes

- The `SendPayload#retry_interval` will now return a processed valid value, or nil when `--retry-interval` is not enabled.
- The retry loop in `SendPayload#run` method is modified to fit the new logic

## Example

```
--retry-interval 12      # 12.0
--retry-interval 12abc   # 12.0
--retry-interval abc12   # 5.0
--retry-interval 0.1     # 5.0
```