### PR TITLE
Retry Interval YAML Value Type Correction

### DIFF
--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -78,7 +78,7 @@ module Hunter
         @retry_interval ||= begin
           ri = Config.retry_interval || @options.retry_interval
           return nil unless ri
-          if !ri.to_s.match(/^\d+(\.\d+)?$/)
+          if !ri.match(/^\d+(\.\d+)?$/)
             puts "Warning! Invalid value detected for --retry-interval. It has now been set to " + [5.0, ri.to_f].max.to_s + "."
           elsif ri.to_f < 5.0
             puts "Warning! The value for --retry-interval is too small. It has now been set to 5.0."

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -78,7 +78,7 @@ module Hunter
         @retry_interval ||= begin
           ri = Config.retry_interval || @options.retry_interval
           return nil unless ri
-          if !ri.match(/^\d+(\.\d+)?$/)
+          if !ri.to_s.match(/^\d+(\.\d+)?$/)
             puts "Warning! Invalid value detected for --retry-interval. It has now been set to " + [5.0, ri.to_f].max.to_s + "."
           elsif ri.to_f < 5.0
             puts "Warning! The value for --retry-interval is too small. It has now been set to 5.0."

--- a/lib/hunter/config.rb
+++ b/lib/hunter/config.rb
@@ -98,7 +98,7 @@ module Hunter
       end
 
       def retry_interval
-        ENV['flight_HUNTER_retry_interval'] || data.fetch(:retry_interval)
+        ENV['flight_HUNTER_retry_interval'] || data.fetch(:retry_interval)&.to_s
       end
 
       def auto_apply


### PR DESCRIPTION
# Overview

This pull request is a successor to [Retry Input Type Validation](https://github.com/openflighthpc/flight-hunter/pull/74) that force the `retry_interval` value read from YAML configuration file to String to ensure the consistency of this value through different sources.