### PR TITLE
safe the empty? call for nil @options.groups in send command

### DIFF
--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -137,7 +137,7 @@ module Hunter
           content: content,
           label: @options.label || Config.presets["label"],
           prefix: @options.prefix || Config.presets["prefix"],
-          groups: @options.groups.empty? ? Config.presets["groups"] : @options.groups,
+          groups: @options.groups&.empty? ? Config.presets["groups"] : @options.groups,
           auth_key: auth_key
         }
       end


### PR DESCRIPTION
#Overview

Currently, a `NoMethodError` will occur when using autorun in send mode to trigger the `hunter` since there is no @options instance variable exists. This pull request tried to fix it with minimum effort without changing the architecture and mechanism of `autorun` command.