### PR TITLE
Fix the issue that broadcast is never triggered under autorun scenario

### DIFF
--- a/lib/hunter/cli.rb
+++ b/lib/hunter/cli.rb
@@ -157,6 +157,7 @@ module Hunter
       c.slop.integer '-p', '--port', "Override server port"
       c.slop.string '-s', '--server', "Override server hostname"
       c.slop.string "--auth", "Override default authentication key"
+      c.slop.bool '--broadcast', "Send identity to all nodes on a given subnet"
       c.slop.string "--broadcast-address", "Specify a broadcast address to use if broadcasting"
       c.slop.array "--groups", "Specify a comma-separated list of groups for this node"
       c.slop.string "--label", "Specify a label to use for this node"

--- a/lib/hunter/cli.rb
+++ b/lib/hunter/cli.rb
@@ -157,7 +157,6 @@ module Hunter
       c.slop.integer '-p', '--port', "Override server port"
       c.slop.string '-s', '--server', "Override server hostname"
       c.slop.string "--auth", "Override default authentication key"
-      c.slop.bool '--broadcast', "Send identity to all nodes on a given subnet"
       c.slop.string "--broadcast-address", "Specify a broadcast address to use if broadcasting"
       c.slop.array "--groups", "Specify a comma-separated list of groups for this node"
       c.slop.string "--label", "Specify a label to use for this node"

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -44,7 +44,7 @@ module Hunter
 
         data = prepare_payload
 
-        broadcast = @options.broadcast_address || Config.broadcast_address
+        broadcast = @options.broadcast || Config.broadcast
         address = @options.broadcast_address || Config.broadcast_address
         host = @options.server || Config.target_host
 

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -39,7 +39,7 @@ module Hunter
       include Hunter::Collector
 
       def run
-        port = @options.port || Config.port.to_s
+        port = @options.port || Config.port&.to_s
         raise "No port provided!" if !port
 
         data = prepare_payload

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -44,18 +44,19 @@ module Hunter
 
         data = prepare_payload
 
-        case @options.broadcast
-        when true
-          # UDP datagram to user provided broadcast address
-          address = @options.broadcast_address || Config.broadcast_address
+        address = @options.broadcast_address || Config.broadcast_address
+        host = @options.server || Config.target_host
+        raise "No target server provided!" unless host || address
+
+        # UDP datagram to user provided broadcast address  
+        if address
           socket = UDPSocket.new
           socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_BROADCAST, true)
           socket.send(data.to_json, 0, address, port)
-        when false
-          # TCP datagram to specific host
-          host = @options.server || Config.target_host
-          raise "No target_host provided!" if !host
+        end
 
+        # TCP datagram to specific host
+        if host
           uri = URI::HTTPS.build(host: host, port: port)
 
           http = Net::HTTP.new(uri.host, uri.port)

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -137,7 +137,7 @@ module Hunter
           content: content,
           label: @options.label || Config.presets["label"],
           prefix: @options.prefix || Config.presets["prefix"],
-          groups: @options.groups.empty? ? Config.presets["groups"] : @options.groups,
+          groups: @options.groups&.empty? ? Config.presets["groups"] : @options.groups,
           auth_key: auth_key
         }
       end

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -44,19 +44,19 @@ module Hunter
 
         data = prepare_payload
 
+        broadcast = @options.broadcast_address || Config.broadcast_address
         address = @options.broadcast_address || Config.broadcast_address
         host = @options.server || Config.target_host
-        raise "No target server provided!" unless host || address
 
-        # UDP datagram to user provided broadcast address  
-        if address
+        if broadcast 
+          # UDP datagram to user provided broadcast address
+          raise "No broadcast targets provided!" unless address
           socket = UDPSocket.new
           socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_BROADCAST, true)
           socket.send(data.to_json, 0, address, port)
-        end
-
-        # TCP datagram to specific host
-        if host
+        else
+          # TCP datagram to specific host
+          raise "No target server provided!" unless host
           uri = URI::HTTPS.build(host: host, port: port)
 
           http = Net::HTTP.new(uri.host, uri.port)

--- a/lib/hunter/config.rb
+++ b/lib/hunter/config.rb
@@ -57,6 +57,10 @@ module Hunter
         ENV['flight_HUNTER_autorun_mode'] || data.fetch(:autorun_mode)
       end
 
+      def broadcast
+        ENV['flight_HUNTER_broadcast'] || data.fetch(:broadcast)
+      end
+
       def broadcast_address
         ENV['flight_HUNTER_broadcast_address'] || data.fetch(:broadcast_address)
       end


### PR DESCRIPTION
# Overview

This branch aims to fix the issue that broadcast is never triggered under autorun scenario.

# Major Changes
- Read the broadcast parameter from both @options variable and Config files.
- Change the logic of triggering the broadcast in Command::SendPayload.
- Added a corresponding `broadcast` function in Config class.

## Minor Fixes
- Fix the issue that the port non exists error is never triggered caused by the inappropriate to_s method used