### PR TITLE
Create PID file when running send

### DIFF
--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -113,7 +113,7 @@ module Hunter
           response.value
           puts "Successful transmission"
           return response
-        rescue Errno::ECONNREFUSED => e
+        rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH => e
           msg = "The server is unavailable\n" + e.message
         rescue Net::HTTPServerException => e
           if response.code == "401"

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -48,6 +48,25 @@ module Hunter
         address = @options.broadcast_address || Config.broadcast_address
         host = @options.server || Config.target_host
 
+        pidpath = ENV['flight_HUNTER_pidfile']
+
+        case pidpath.nil?
+        when true
+          pf = PidFile.new
+        when false
+          piddir, pidfile = pidpath.yield_self do |s|
+            [File.dirname(s), s.split('/').pop]
+          end
+
+          pf = PidFile.new(
+            piddir: piddir,
+            pidfile: pidfile
+          )
+        end
+
+        # Give Flight Service a chance to fetch the PID file
+        sleep(1)
+
         if broadcast 
           # UDP datagram to user provided broadcast address
           raise "No broadcast targets provided!" unless address


### PR DESCRIPTION
This PR updates the `send` command to create a PID file, so that Flight Service can track that it has started. The ability to specify the pidfile path is only accepted through an environment variable, because it's an option meant for us to use instead of users.