### PR TITLE
Don't duplicate PID file when using `include-self`

### DIFF
--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -80,6 +80,8 @@ module Hunter
             groups: []
           )
 
+          ENV['flight_HUNTER_pidfile'] = nil
+
           Commands::SendPayload.new(OpenStruct.new, opts).run!
         end
 

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -50,10 +50,7 @@ module Hunter
 
         pidpath = ENV['flight_HUNTER_pidfile']
 
-        case pidpath.nil?
-        when true
-          pf = PidFile.new
-        when false
+        unless pidpath.nil?
           piddir, pidfile = pidpath.yield_self do |s|
             [File.dirname(s), s.split('/').pop]
           end


### PR DESCRIPTION
Previously, using `--include-self` would raise an error because the command attempts to create a PID file with the same name as the one created by the `hunt` command. This PR introduces two new changes:
- Un-set `ENV['flight_HUNTER_pidfile']` before running `send` as part of `include-self`
- In the `send` command, don't create a PID file if no environment variable is set.
  - If no variable is set, it _probably_ isn't being used as background service, and we don't need to track it's process ID.