### PR TITLE
Handling the Unexpected Nil Line Read by Client TCPSocket

### DIFF
--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -131,7 +131,11 @@ module Hunter
               headers = {}
               loop do
                 line = client.gets
-                raise Net::HTTPError if line == nil
+                if line == nil
+                  client.puts "HTTP/1.1 500\r\n"
+                  client.close
+                  raise Net::HTTPError
+                end
                 line = line.split(" ", 2)
                 break if line[0] == ""
                 headers[line[0].chop] = line[1].strip

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -129,7 +129,10 @@ module Hunter
               client = server.accept
 
               headers = {}
-              while line = client.gets.split(' ', 2)
+              loop do
+                line = client.gets
+                raise Net::HTTPError if line == nil
+                line = line.split(" ", 2)
                 break if line[0] == ""
                 headers[line[0].chop] = line[1].strip
               end
@@ -160,6 +163,8 @@ module Hunter
               process_packet(data: payload)
             rescue Errno::ECONNRESET => e
               puts "Caught exception: #{e.message}"
+            rescue Net::HTTPError
+              puts "Caught exception: unknown nil line captured from the client socket"
             end
           end
         end


### PR DESCRIPTION
Currently, when the TCP server of a hunt session tries to read the content of a received request, it might get nil and then terminate the TCP thread. While the specific reason has not been discovered yet, this fix aims to handle this situation by raising an error and responding to the client with status code 500 under this nil situation.