### PR TITLE
Dev/introduce udpmoose

### DIFF
--- a/lib/hunter/cli.rb
+++ b/lib/hunter/cli.rb
@@ -61,7 +61,7 @@ module Hunter
       cli_syntax(c)
       c.summary = 'Listen for broadcasting clients'
       c.slop.bool '--allow-existing', 'Allow replacement of existing entries'
-      c.slop.string '--port', 'Override port'
+      c.slop.integer '--port', 'Override port'
       c.slop.bool '--include-self', 'Immediately try to send payload to self'
       c.slop.string '--auth', "Override default authentication key"
       c.slop.string '--auto-parse', 'Automatically parse nodes matching this regex'
@@ -155,14 +155,13 @@ module Hunter
       c.summary = 'Push my identity plus optional additional details to server'
       c.slop.string '-c', '--command', "Command to use to generate sent content"
       c.slop.integer '-p', '--port', "Override server port"
-      c.slop.string '-s', '--server', "Override server hostname"
+      c.slop.string '-s', '--server', "Override server hostname, could be a broadcast address"
+      c.slop.integer '--max-server', "Specify a maximum number of hunting servers to be sent to when using broadcast address"
       c.slop.string "--auth", "Override default authentication key"
-      c.slop.bool '--broadcast', "Send identity to all nodes on a given subnet"
-      c.slop.string "--broadcast-address", "Specify a broadcast address to use if broadcasting"
       c.slop.array "--groups", "Specify a comma-separated list of groups for this node"
       c.slop.string "--label", "Specify a label to use for this node"
       c.slop.string "--prefix", "Specify a prefix to use for this node"
-      c.slop.string "--retry-interval", "Specify a number of seconds, send will be re-attempted at this interval until successful."
+      c.slop.integer "--timeout", "Specify an integer number of seconds, send will be re-attempted within this time limit"
       c.action Commands, :send_payload
     end
   end

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -78,7 +78,8 @@ module Hunter
             server: Config.target_host || 'localhost',
             auth: @auth_key,
             broadcast: false,
-            groups: []
+            groups: [],
+            socket: socket
           )
 
           ENV['flight_HUNTER_pidfile'] = nil
@@ -87,7 +88,7 @@ module Hunter
         end
 
         socket.receive do |payload|
-          process_packet(JSON.parse(payload))
+          process_packet(data: JSON.parse(payload))
         end
 
       end

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -87,8 +87,8 @@ module Hunter
           Commands::SendPayload.new(OpenStruct.new, opts).run!
         end
 
-        socket.receive do |payload|
-          process_packet(data: JSON.parse(payload))
+        socket.receive do |client_ip, payload|
+          process_packet(data: JSON.parse(payload).merge!({ 'ip' => client_ip }))
         end
 
       end

--- a/lib/hunter/commands/hunt.rb
+++ b/lib/hunter/commands/hunt.rb
@@ -32,6 +32,7 @@ require_relative '../config'
 require_relative '../node'
 require_relative '../node_list'
 require_relative '../profile_cli'
+require_relative '../udp_moose'
 
 
 module Hunter

--- a/lib/hunter/commands/parse.rb
+++ b/lib/hunter/commands/parse.rb
@@ -34,7 +34,7 @@ module Hunter
     class Parse < Command
       def run
         @buffer = NodeList.load(Config.node_buffer)
-        raise "No nodes in buffer" if @buffer.nodes.empty?
+        raise "No nodes in buffer" unless !@buffer.nodes&.empty?
         @parsed = NodeList.load(Config.node_list)
 
         if @options.skip_used_index

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -71,7 +71,6 @@ module Hunter
         # do not open conflict socket when send to self
         socket = @options.socket || UDPMoose.new(port)
         request_id = socket.send(data.to_json, host, port, max_host, timeout)
-        puts "sent"
         socket.get_responses(request_id) do |responses|
           raise "send request timeout" if responses.empty?
           responses.each do |server_ip|

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -50,7 +50,7 @@ module Hunter
         
         max_host = @options.max_server || Config.max_target&.to_i || 1
 
-        timeout = @options.timeout || Config.timeout&.to_i  || 10
+        timeout = @options.timeout || Config.timeout&.to_i || 10
 
         pidpath = ENV['flight_HUNTER_pidfile']
 

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -32,6 +32,7 @@ require 'net/http'
 
 require_relative '../command'
 require_relative '../collector'
+require_relative '../udp_moose'
 
 module Hunter
   module Commands

--- a/lib/hunter/commands/send.rb
+++ b/lib/hunter/commands/send.rb
@@ -68,9 +68,11 @@ module Hunter
         # Give Flight Service a chance to fetch the PID file
         sleep(1)
 
-        socket = UDPMoose.new(port)
-        socket.send(data.to_json, host, port, max_host, timeout)
-        socket.get_responses do |responses|
+        # do not open conflict socket when send to self
+        socket = @options.socket || UDPMoose.new(port)
+        request_id = socket.send(data.to_json, host, port, max_host, timeout)
+        puts "sent"
+        socket.get_responses(request_id) do |responses|
           raise "send request timeout" if responses.empty?
           responses.each do |server_ip|
             puts "Successful transmission to: #{server_ip}"

--- a/lib/hunter/config.rb
+++ b/lib/hunter/config.rb
@@ -57,16 +57,12 @@ module Hunter
         ENV['flight_HUNTER_autorun_mode'] || data.fetch(:autorun_mode)
       end
 
-      def broadcast
-        ENV['flight_HUNTER_broadcast'] || data.fetch(:broadcast)
-      end
-
-      def broadcast_address
-        ENV['flight_HUNTER_broadcast_address'] || data.fetch(:broadcast_address)
-      end
-
       def target_host
         ENV['flight_HUNTER_target_host'] || data.fetch(:target_host)
+      end
+
+      def max_target
+        ENV['flight_HUNTER_max_target'] || data.fetch(:max_target)
       end
 
       def content_command
@@ -101,8 +97,8 @@ module Hunter
         ENV['flight_HUNTER_skip_used_index'] || data.fetch(:skip_used_index)
       end
 
-      def retry_interval
-        ENV['flight_HUNTER_retry_interval'] || data.fetch(:retry_interval)&.to_s
+      def timeout
+        ENV['flight_HUNTER_timeout'] || data.fetch(:timeout)
       end
 
       def auto_apply

--- a/lib/hunter/udp_moose.rb
+++ b/lib/hunter/udp_moose.rb
@@ -1,0 +1,581 @@
+# frozen_string_literal: true
+
+require 'socket'
+require 'json'
+
+class UDPMoose
+  attr_reader :buffers, :requests
+
+  def initialize(port = 0, ingress = false)
+    @udp_socket = UDPSocket.new
+    @udp_socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_BROADCAST, true)
+    @udp_socket.bind('0.0.0.0', port)
+
+    @ingress = ingress
+
+    @requests = {}
+    @buffers = {}
+
+    @receive_lock = UDPMooseLock.new
+
+    @receives = []
+
+    listener
+    timer
+  end
+
+  #
+  # client methods
+  #
+  #
+  #
+
+  # user send request
+  def send(body, server_ip_range, server_port, max_connection = 1, max_timeout = 10)
+    # build the request
+    request_id = ((Time.now.to_f * 1000).to_i.to_s + body).hash.to_s
+    puts request_id
+    request = UDPMooseRequest.new(request_id, body, server_ip_range, server_port, max_connection, max_timeout)
+
+    @requests[request_id] = request
+
+    Thread.new do
+      # enqueue the initial handshake request connection
+      request.enqueue_by_connection_key(request_id)
+
+      # loop until request end
+      while request.requesting?
+
+        connection = request.dequeue
+        @udp_socket.send(connection.payload, 0, connection.server_ip, request.server_port)
+
+        request.lock_request
+        request.wait_request if request.idle? && request.requesting?
+        request.unlock_request
+
+      end
+    end
+
+    # return the request id for user access in the future
+    request_id
+  end
+
+  def get_responses(request_id)
+    request = @requests[request_id]
+    request.lock_response
+    request.wait_response if request.requesting?
+    request.unlock_response
+
+    responses = [].tap do |arr|
+      request.connections.each do |key, connection|
+        arr << connection.server_ip if connection.closed? && key != request_id
+      end
+    end
+
+    yield responses if block_given?
+  end
+
+  #
+  # server methods
+  #
+  #
+  #
+
+  def receive
+    loop do
+      lock_receive
+      wait_receive if @receives.empty?
+      unlock_receive
+
+      yield @receives.shift if block_given?
+    end
+  end
+
+  private
+
+  # create a thread for listening to the income packets
+  def listener
+    Thread.new do
+      loop do
+        msg, addr = @udp_socket.recvfrom(64_000) # thread blocked until new packet recieved
+        hash_msg = JSON.parse(msg)
+
+        # handshake request received
+        if @ingress && hash_msg['type'] == 'stu'
+
+          unless @buffers[hash_msg['id']]
+            @buffers[hash_msg['id']] =
+              UDPMooseBuffer.new(hash_msg['total'], addr[2], addr[1])
+          end
+          jack(hash_msg['id']) unless @buffers[hash_msg['id']]&.packet&.> 0
+
+        # body fragment received
+        elsif hash_msg['type'] == 'request'
+
+          buffer = @buffers[hash_msg['id']]
+
+          if hash_msg['packet'] + 1 == buffer&.join!(hash_msg['packet'], hash_msg['content']) && !buffer.completed?
+            response(hash_msg['id'])
+          elsif buffer&.completed?
+            ivan(hash_msg['id'])
+            @receives << buffer.buffer if buffer.enqueue?
+            continue_receive unless @receives.empty?
+          end
+
+        # handwave response from client received
+        elsif hash_msg['type'] == 'bye'
+
+          # remove the buffer
+          @buffers&.delete(hash_msg['id'])
+
+        # handshake response received
+        elsif hash_msg['type'] == 'jack'
+
+          request = @requests[hash_msg['id']]
+          # connection can be created
+
+          request&.lock_request
+          if request&.create_connection(addr[2])
+
+            request.enqueue_by_connection_key(addr[2])
+            request.continue_request
+
+          end
+          request&.unlock_request
+
+        # body response received
+        elsif hash_msg['type'] == 'response'
+
+          request = @requests[hash_msg['id']]
+          connection = request&.connections&.[](addr[2])
+
+          if connection&.match_packet?(hash_msg['packet'].to_i - 1)
+
+            request.lock_request
+
+            connection.next_packet
+            request.enqueue_by_connection_key(addr[2])
+
+            request.continue_request
+            request.unlock_request
+
+          end
+
+        # handwave request from server received
+        elsif hash_msg['type'] == 'ivan'
+
+          request = @requests[hash_msg['id']]
+
+          if request
+
+            request.lock_request
+            if request.complete_connection(addr[2]) && !request.requesting?
+              request.continue_request
+              request.continue_response
+            end
+            request.unlock_request
+
+            bye(hash_msg['id'], addr[2], addr[1])
+
+          end
+
+        end
+      end
+    end
+  end
+
+  # create a thread to check requests timeout
+  def timer
+    Thread.new do
+      loop do
+        @requests.each_value do |request|
+          request.lock_request
+          request.check_timeout
+          request.continue_request unless request.idle? && request.requesting?
+          request.continue_response unless request.requesting?
+          request.unlock_request
+        end
+
+        sleep(1)
+      end
+    end
+  end
+
+  def jack(request_id)
+    buffer = @buffers[request_id]
+    payload = {
+      type: 'jack',
+      id: request_id
+    }.to_json
+
+    @udp_socket.send(payload, 0, buffer.client_ip, buffer.client_port)
+  end
+
+  def response(request_id)
+    buffer = @buffers[request_id]
+    payload = {
+      type: 'response',
+      id: request_id,
+      packet: buffer.packet
+    }.to_json
+
+    @udp_socket.send(payload, 0, buffer.client_ip, buffer.client_port)
+  end
+
+  def ivan(request_id)
+    buffer = @buffers[request_id]
+    payload = {
+      type: 'ivan',
+      id: request_id
+    }.to_json
+
+    @udp_socket.send(payload, 0, buffer.client_ip, buffer.client_port)
+  end
+
+  def bye(request_id, server_ip, server_port)
+    @buffers[request_id]
+    payload = {
+      type: 'bye',
+      id: request_id
+    }.to_json
+
+    @udp_socket.send(payload, 0, server_ip, server_port)
+  end
+
+  #
+  # server thread lock methods
+  #
+  #
+  #
+
+  def lock_receive
+    @receive_lock.lock
+  end
+
+  def unlock_receive
+    @receive_lock.unlock
+  end
+
+  def wait_receive
+    @receive_lock.wait
+  end
+
+  def continue_receive
+    @receive_lock.continue
+  end
+
+  #
+  # private classes
+  #
+  #
+  #
+
+  class UDPMooseLock
+    def initialize
+      @mutex = Mutex.new
+      @condition = ConditionVariable.new
+      @waiting = false
+    end
+
+    def lock
+      @mutex.lock
+    end
+
+    def unlock
+      @mutex.unlock
+    end
+
+    def wait
+      @waiting = true
+      @condition.wait(@mutex)
+    end
+
+    def continue
+      return unless @waiting
+
+      @waiting = false
+      @condition.signal
+    end
+  end
+
+  class UDPMooseRequest
+    attr_reader :server_port, :connections
+
+    def initialize(id, body, server_ip_range, server_port, max_connection, max_timeout)
+      @request_lock = UDPMooseLock.new
+      @response_lock = UDPMooseLock.new
+
+      @id = id
+      @body_fragments = split_body(body)
+      @connections = {}
+      @connections[@id] = UDPMooseHandShakeConnection.new(@id, @body_fragments, server_ip_range)
+      @server_port = server_port
+
+      @queue = []
+
+      @max_connection = max_connection
+
+      @timestamp = Time.now.to_f
+      @handshake_timestamp = @timestamp
+      @max_timeout = max_timeout
+    end
+
+    #
+    # thread control methods
+    #
+    #
+    #
+
+    def lock_request
+      @request_lock.lock
+    end
+
+    def unlock_request
+      @request_lock.unlock
+    end
+
+    def wait_request
+      @request_lock.wait
+    end
+
+    def continue_request
+      @request_lock.continue
+    end
+
+    def lock_response
+      @response_lock.lock
+    end
+
+    def unlock_response
+      @response_lock.unlock
+    end
+
+    def wait_response
+      @response_lock.wait
+    end
+
+    def continue_response
+      @response_lock.continue
+    end
+
+    #
+    # request queue management methods
+    #
+    #
+    #
+
+    # enqueue the connection to be executed
+    def enqueue_by_connection_key(connection_id)
+      @queue << @connections[connection_id]
+    end
+
+    # fetch the next connection to be executed and update the timestamp
+    def dequeue
+      connection = @queue.shift
+      @timestamp = Time.now.to_f if idle?
+      connection
+    end
+
+    # check if the queue is empty
+    def idle?
+      @queue.empty?
+    end
+
+    #
+    # connection life cycle management
+    #
+    #
+    #
+
+    def create_connection(server_ip)
+      if connections[@id].connecting? && !@connections[server_ip]
+
+        @connections[server_ip] = UDPMooseRequestConnection.new(@id, @body_fragments, server_ip)
+
+        # close handshake connection if handshake finished
+        @connections[@id].close if @connections.length - 1 == @max_connection
+
+        return @connections[server_ip]
+
+      end
+
+      nil
+    end
+
+    def complete_connection(server_ip)
+      @connections[server_ip]&.close
+    end
+
+    # check timeout status to retry or terminate the connections
+    def check_timeout
+      current_timestamp = Time.now.to_f
+
+      # neither reached the limitation of maximum connections nor handshake timeout
+      if @connections[@id].connecting? && current_timestamp - @handshake_timestamp <= @max_timeout
+        enqueue_by_connection_key(@id)
+
+      # some connections established
+      elsif @connections.length > 1
+        @connections[@id].close
+
+      # no connection established
+      else
+        @connections[@id].timeout
+      end
+
+      if requesting? && current_timestamp - @timestamp > 1 && current_timestamp - @timestamp <= @max_timeout
+
+        @connections.each do |key, _connection|
+          enqueue_by_connection_key(key) if !key == @id && @connection.connecting?
+        end
+
+      elsif requesting? && current_timestamp - @timestamp > @max_timeout
+
+        @connections.each_value do |connection|
+          # the closed connections won't be transferred to timeout connections, see UDPMooseConnection#close and UDPMooseConnection#timeout
+          connection.timeout if connection.connecting?
+        end
+
+      end
+    end
+
+    # check if any connecting connection remains
+    def requesting?
+      @connections.each_value do |connection|
+        return true if connection.connecting?
+      end
+
+      false
+    end
+
+    private
+
+    # split a long string into an array of string fragments regarding the packet_limit
+    def split_body(body, packet_limit = 60_000)
+      body_fragments = []
+
+      i = 15_000 # index of string character
+      temp_string = body[0...15_000]
+      temp_bytesize = temp_string.bytesize
+      while i < body.length
+
+        if temp_bytesize + body[i].bytesize <= packet_limit
+          temp_string << body[i]
+          temp_bytesize += body[i].bytesize
+        else
+          body_fragments << temp_string
+          j = i + 14_999
+          temp_string = body[i..j]
+          temp_bytesize = temp_string.bytesize
+          i = j
+        end
+
+        i += 1
+
+      end
+
+      body_fragments << temp_string
+    end
+  end
+
+  class UDPMooseConnection
+    attr_reader :server_ip
+
+    def initialize(id, body_fragments, server_ip)
+      @id = id
+      @body_fragments = body_fragments
+      @server_ip = server_ip
+      @status = 0
+    end
+
+    def connecting?
+      @status.zero?
+    end
+
+    def close
+      return unless connecting?
+
+      @status = 1
+    end
+
+    def closed?
+      @status == 1
+    end
+
+    def timeout
+      return unless connecting?
+
+      @status = 2
+    end
+
+    def timeout?
+      @status == 2
+    end
+  end
+
+  class UDPMooseHandShakeConnection < UDPMooseConnection
+    def payload
+      {
+        type: 'stu',
+        id: @id,
+        total: @body_fragments.length
+      }.to_json
+    end
+  end
+
+  class UDPMooseRequestConnection < UDPMooseConnection
+    def initialize(id, body_fragments, server_ip)
+      super(id, body_fragments, server_ip)
+      @packet = 0
+    end
+
+    def payload
+      {
+        type: 'request',
+        id: @id,
+        packet: @packet,
+        content: @body_fragments[@packet]
+      }.to_json
+    end
+
+    def next_packet
+      @packet += 1
+    end
+
+    def match_packet?(packet)
+      packet == @packet
+    end
+  end
+
+  class UDPMooseBuffer
+    attr_reader :packet, :client_ip, :client_port, :buffer
+
+    def initialize(total, client_ip, client_port)
+      @total = total
+      @packet = 0
+      @buffer = ''
+      @client_ip = client_ip
+      @client_port = client_port
+      @enqueued = false
+    end
+
+    def join!(packet, content)
+      if @packet == packet && !completed?
+        @buffer += content
+        @packet += 1
+      end
+
+      @packet
+    end
+
+    def completed?
+      @packet == @total
+    end
+
+    def enqueue?
+      return false if @enqueued
+
+      @enqueued = true
+    end
+  end
+end

--- a/lib/hunter/udp_moose.rb
+++ b/lib/hunter/udp_moose.rb
@@ -34,7 +34,6 @@ class UDPMoose
   def send(body, server_ip_range, server_port, max_connection = 1, max_timeout = 10)
     # build the request
     request_id = ((Time.now.to_f * 1000).to_i.to_s + body).hash.to_s
-    puts request_id
     request = UDPMooseRequest.new(request_id, body, server_ip_range, server_port, max_connection, max_timeout)
 
     @requests[request_id] = request

--- a/lib/hunter/udp_moose.rb
+++ b/lib/hunter/udp_moose.rb
@@ -86,7 +86,10 @@ class UDPMoose
       wait_receive if @receives.empty?
       unlock_receive
 
-      yield @receives.shift if block_given?
+      if block_given?
+        buffer = @receives.shift
+        yield buffer.client_ip, buffer.buffer
+      end
     end
   end
 
@@ -117,7 +120,7 @@ class UDPMoose
             response(hash_msg['id'])
           elsif buffer&.completed?
             ivan(hash_msg['id'])
-            @receives << buffer.buffer if buffer.enqueue?
+            @receives << buffer if buffer.enqueue?
             continue_receive unless @receives.empty?
           end
 


### PR DESCRIPTION
# Overview
Previously, Hunter used a mix of UDP and TCP protocols to address broadcasting and point-to-point transmission scenarios separately, resulting in inconsistency in the code and user experience. This branch introduces a new UDP-based dedicated application-layer protocol, UDPMoose, to integrate the fragmented states between broadcasting and single-host transmission, as well as ensure reliable data transfer. Besides, Hunter will now automatically retry the failed transmission within a given maximum timeout. Therefore, the retry interval is no longer determined by users.

# Major Changes
- The following options are deprecated for `hunter send` as a CLI command:
   - `--broadcast`
   - `--broadcast-address`
   - `--retry-interval`
- Correspondingly, the following configs are deprecated:
   - `broadcast`
   - `broadcast_address`
   - `retry_interval`

- The behavior of the following option(s) is improved for `hunter send` as a CLI command:
   - `--server <string>` or `-s <string>` It now supports both normal IP address and broadcast address.
- Correspondingly, the behavior of the following config(s) is improved:
   - `target_host`

-  The following options are added for `hunter send` as a CLI command:
   - `--max-server <integer>` This option is used to specify the maximum number of hosts to be sent to when using broadcast address for `--server` option. Here the term `host` generally means the server running a `hunter hunt` session. By default, it is set to 1.
   - `--timeout <integer>` This option is to specify the maximum timeout seconds. If the number of successful transmissions doesn't reach the max server number, the send process will automatically keep retrying until reaching this time limit. By default, it is set to 10
-  Correspondingly, the following configs are added:
   - `max_target`
   - `timeout`
- With the introduction of UDPMoose, the implementation of the hunt command no longer maintains two threads. They are now managed by UDPMoose.
- With the introduction of UDPMoose, the implementation of the send command no longer constructs different payloads for TCP and UDP scenarios.

# Examples
- For a subnet with 100 instances, 2 nodes are hunting and others doing nothing, the broadcast address of that subnet is '10.100.255.255':
   - Running `flight hunter send -s 10.100.255.255` without other options, only one of the two hunting nodes can capture this sending node. The sending process ends after that. Otherwise, there is a connection problem, say, the sending process will by default reach the timeout limit after 10 seconds of retrying and end with a failed result.
   - Running `flight hunter send -s 10.100.255.255 --max-server 2`. Both hunting nodes can capture this sending node under normal circumstances.
   - Running `flight hunter send -s 10.100.255.255 --max-server 3 --timeout 180`. Both hunting nodes can capture this sending node under normal circumstances.  After that, the sending process will keep retrying for 3 minutes and then close.

# Other Changes
- Fix an unhandled error in parse.rb that invokes the `empty?` method on a nil class when the buffer list is empty.
- Fix the inconsistency between the type of the `port` option for send and hunt commands.



