### PR TITLE
Add `--blank` option to `parse`

### DIFF
--- a/etc/config.yml.ex
+++ b/etc/config.yml.ex
@@ -47,9 +47,8 @@
 #     - example_group1
 #     - example_group2
 #
-# Attempt to shorten given hostnames by removing everything after the 
-# first "." (optional)
-# short_hostname: true
+# How to handle hostnames. If set, must be one of "long", "short" or "blank" (optional)
+# default_hostnames:
 #
 # Default number start value for automatically parsed nodes
 # default_start: "01"

--- a/lib/hunter/cli.rb
+++ b/lib/hunter/cli.rb
@@ -147,7 +147,7 @@ module Hunter
       c.slop.bool '--allow-existing', 'Allow replacement of existing entries'
       c.slop.string '--skip-used-index', 'Ignore errors if a label index is already in use'
       c.slop.bool '--dry-run', 'Print generated node labels without parsing nodes'
-      c.slop.bool '--blank', 'Default to empty label instead of hostname' 
+      c.slop.string '--default-hostnames', "Set the way that hostnames are processed in node labels. Must be 'short', 'long' or 'blank'"
       c.action Commands, :parse
     end
 

--- a/lib/hunter/cli.rb
+++ b/lib/hunter/cli.rb
@@ -147,6 +147,7 @@ module Hunter
       c.slop.bool '--allow-existing', 'Allow replacement of existing entries'
       c.slop.string '--skip-used-index', 'Ignore errors if a label index is already in use'
       c.slop.bool '--dry-run', 'Print generated node labels without parsing nodes'
+      c.slop.bool '--blank', 'Default to empty label instead of hostname' 
       c.action Commands, :parse
     end
 

--- a/lib/hunter/commands/parse.rb
+++ b/lib/hunter/commands/parse.rb
@@ -197,7 +197,7 @@ module Hunter
 
           # Pre-generate the label, if possible
           prefill = answers[:active_choice].value.yield_self do |node|
-            node.preset_label || node.auto_label(used_names: @used_strings + reserved, default_prefix: @options.prefix, default_start: @options.start)
+            node.preset_label || node.auto_label(used_names: @used_strings + reserved, default_prefix: @options.prefix, default_start: @options.start, blank: @options.blank)
           end
 
           # Ask the user for a label

--- a/lib/hunter/commands/parse.rb
+++ b/lib/hunter/commands/parse.rb
@@ -209,7 +209,7 @@ module Hunter
           end
 
           # Ask the user for a label
-          name = prompt.ask("Choose label:", quiet: true, value: prefill) do |q|
+          name = prompt.ask("Enter the alias to be used as a label for node '#{answers[:active_choice].value.hostname}'\nChoose label:", quiet: true, value: prefill) do |q|
             q.validate ->(input) { !reserved.include?(input) }, "Label already exists"
           end.to_s.strip
 

--- a/lib/hunter/commands/parse.rb
+++ b/lib/hunter/commands/parse.rb
@@ -42,6 +42,10 @@ module Hunter
         else
           @skip_used = Config.skip_used_index
         end
+        
+        if @options.default_hostnames && (!["long", "short", "blank"].include? @options.default_hostnames.downcase) then
+          raise "Invalid argument for 'default_hostnames', must be 'long', 'short', or 'blank'"
+        end
 
         # Load auto_apply rules list so we can check if it's valid
         Config.auto_apply
@@ -197,7 +201,11 @@ module Hunter
 
           # Pre-generate the label, if possible
           prefill = answers[:active_choice].value.yield_self do |node|
-            node.preset_label || node.auto_label(used_names: @used_strings + reserved, default_prefix: @options.prefix, default_start: @options.start, blank: @options.blank)
+            node.preset_label || node.auto_label(used_names: @used_strings + reserved,
+                                                 default_prefix: @options.prefix,
+                                                 default_start: @options.start,
+                                                 default_hostnames: @options.default_hostnames || Config.default_hostnames
+                                                )
           end
 
           # Ask the user for a label

--- a/lib/hunter/config.rb
+++ b/lib/hunter/config.rb
@@ -85,8 +85,8 @@ module Hunter
         ENV['flight_HUNTER_auto_parse'] || data.fetch(:auto_parse)
       end
 
-      def short_hostname
-        ENV['flight_HUNTER_short_hostname'] || data.fetch(:short_hostname)
+      def default_hostnames
+        ENV['flight_HUNTER_default_hostnames'] || data.fetch(:default_hostnames) || "long"
       end
 
       def default_start

--- a/lib/hunter/node.rb
+++ b/lib/hunter/node.rb
@@ -86,9 +86,10 @@ module Hunter
       @label || @presets["label"]
     end
 
-    def auto_label(used_names: NodeList.load(Config.node_list).nodes.map(&:label), default_prefix: nil, default_start: nil)
+    def auto_label(used_names: NodeList.load(Config.node_list).nodes.map(&:label), default_prefix: nil, default_start: nil, blank: false)
       prefix = @presets["prefix"] || default_prefix
-      return (Config.short_hostname ? @hostname.split(".").first : @hostname) unless prefix
+      hostname = (Config.short_hostname ? @hostname.split(".").first : @hostname)
+      return (blank ? "" : hostname) unless prefix
 
       start = Config.prefix_starts[prefix] || default_start || Config.default_start
       i = start.to_i

--- a/lib/hunter/node.rb
+++ b/lib/hunter/node.rb
@@ -86,10 +86,17 @@ module Hunter
       @label || @presets["label"]
     end
 
-    def auto_label(used_names: NodeList.load(Config.node_list).nodes.map(&:label), default_prefix: nil, default_start: nil, blank: false)
+    def auto_label(used_names: NodeList.load(Config.node_list).nodes.map(&:label), default_prefix: nil, default_start: nil, default_hostnames: "long")
       prefix = @presets["prefix"] || default_prefix
-      hostname = (Config.short_hostname ? @hostname.split(".").first : @hostname)
-      return (blank ? "" : hostname) unless prefix
+      hostname = case default_hostnames
+                 when "long"
+                   @hostname
+                 when "short"
+                   @hostname.split(".").first
+                 when "blank"
+                   ""
+                 end
+      return hostname unless prefix
 
       start = Config.prefix_starts[prefix] || default_start || Config.default_start
       i = start.to_i


### PR DESCRIPTION
This PR adds a new option, `--blank`, to the `parse` command. With it set, the hostname will never be used as the default for manual parsing, so if alternative options are not available then the prefilled label will be blank.