### PR TITLE
Show/list inconsistencies

### DIFF
--- a/lib/hunter/commands/show.rb
+++ b/lib/hunter/commands/show.rb
@@ -44,7 +44,8 @@ module Hunter
             node.id,
             node.hostname,
             node.ip,
-            node.groups.any? ? node.groups.join("|") : "|"
+            node.groups.any? ? node.groups.join("|") : "|",
+            node.content
           ]
           puts a.join("\t")
         else

--- a/lib/hunter/node.rb
+++ b/lib/hunter/node.rb
@@ -61,7 +61,7 @@ module Hunter
       when true
         [Paint[id, :cyan], hostname, ip, pretty_groups, pretty_presets]
       when false
-        [Paint[id, :cyan], label, hostname, ip, pretty_groups]
+        [Paint[id, :cyan], hostname, ip, pretty_groups, label]
       end
     end
 

--- a/lib/hunter/table.rb
+++ b/lib/hunter/table.rb
@@ -51,7 +51,7 @@ module Hunter
                   when true
                     ['ID', 'Hostname', 'IP', 'Groups', 'Presets']
                   when false
-                    ['ID', 'Label', 'Hostname', 'IP', 'Groups']
+                    ['ID', 'Hostname', 'IP', 'Groups', 'Label']
                   end
         rows = nodes.map { |n| n.to_table_row(buffer: buffer) }
 


### PR DESCRIPTION
This PR introduces two changes to how we print nodes:
- A node's content (the data that was sent as a payload to Hunter) is now included in the `--plain` output
- The `label` column of the tables generated by `Table.from_nodes` is now at the end of the table, to keep as many consecutive columns as possible consistent.