### PR TITLE
Fix blank hostname for automatic parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Flight Hunter has some required configuration based on the environment it is bei
 - `auto_parse` - A regular expresssion, nodes matching this expression will bypass the buffer and be parsed immediately when `hunt`ed
 - `auto_apply` - Specify pairs of regular expressions and Flight Profile identities. If a node label matches the regular expression (when the node is parsed) then the corresponding Flight Profile identity is applied to it.
 - `presets` - Specify preset data to send when sending to self using `hunt` with `--include self`. Includes `label`, `prefix` and `groups`.
-- `short_hostname` - If true, everything beyond the first `.` in a node's hostname will be removed when generating a label for it from the hostname.
+- `default_label` - Must be either `long` (default), `short` or `blank`. When generating a label for a node, if the hostname would be used, it may be either shortened or made blank intead.
 - `default_start` - The default start index when parsing automatically with a prefix. Note that this must be enclosed in quotation marks.
 - `prefix_starts` - Custom start values for specified prefixes when automatically parsing. Note that given start values must be enclosed in quotation marks.
 - `skip_used_index` - If automatic parsing attempts to create a label which already exists, skip that label and give the node a higher suffix until an unusued label is found.
@@ -96,7 +96,7 @@ Select nodes: (Scroll for more nodes)
   ⬡ hostname3 - 10.50.0.42
 ```
 
-Selecting a node from this menu will prompt the user for a label to assign to the node. If the node was sent with a `--label` or a `--prefix` (or if the user has chosen command line options for `prefix` and `start`), the input prompt will be pre-populated with the given data.
+Selecting a node from this menu will prompt the user for a label to assign to the node. If the node was sent with a `--label` or a `--prefix` (or if the user has chosen command line options for `prefix` and `start`), the input prompt will be pre-populated with the given data. If these are not given, the prompt will give the node hostname instead. The `--default-label` option may be used to `short`en this value, or make it `blank` entirely.
 
 #### Automatic parser
 
@@ -114,7 +114,7 @@ Labels may also have their naming data pre-set by using the `--label` or `--pref
 
 * Nodes without a preset label but with a preset prefix will generate a label involving the prefix and a numerical suffix determined based on the start value set through either the `default_start` or `prefix_starts` config options.
 
-* Nodes without either of the above will take their hostnames as labels, which may be shortened up to the first `.` using the `short_hostname` config option.
+* Nodes without either of the above will take their hostnames as labels, which may be shortened up to the first `.` using the `short` value for the `default_label` config option.
 
 ### Switching between buffer and processed list
 

--- a/etc/config.yml.ex
+++ b/etc/config.yml.ex
@@ -47,7 +47,7 @@
 #     - example_group1
 #     - example_group2
 #
-# How to handle hostnames. If set, must be one of "long", "short" or "blank" (optional)
+# How to process a node's hostname into a default label. If set, must be one of "long", "short" or "blank" (optional)
 # default_hostnames:
 #
 # Default number start value for automatically parsed nodes

--- a/lib/hunter/cli.rb
+++ b/lib/hunter/cli.rb
@@ -147,7 +147,7 @@ module Hunter
       c.slop.bool '--allow-existing', 'Allow replacement of existing entries'
       c.slop.string '--skip-used-index', 'Ignore errors if a label index is already in use'
       c.slop.bool '--dry-run', 'Print generated node labels without parsing nodes'
-      c.slop.string '--default-hostnames', "Set the way that hostnames are processed in node labels. Must be 'short', 'long' or 'blank'"
+      c.slop.string '--default-label', "Set the way that hostnames are processed in node labels. Must be 'short', 'long' or 'blank'"
       c.action Commands, :parse
     end
 

--- a/lib/hunter/commands/parse.rb
+++ b/lib/hunter/commands/parse.rb
@@ -43,10 +43,10 @@ module Hunter
           @skip_used = Config.skip_used_index
         end
         
-        if @options.default_hostnames && (!["long", "short", "blank"].include? @options.default_hostnames.downcase) then
-          raise "Invalid argument for 'default_hostnames', must be 'long', 'short', or 'blank'"
+        if @options.default_label && (!["long", "short", "blank"].include? @options.default_label.downcase) then
+          raise "Invalid argument for 'default_label', must be 'long', 'short', or 'blank'"
         end
-        @default_hostnames = @options.default_hostnames || Config.default_hostnames
+        @default_label = @options.default_label || Config.default_label
 
         # Load auto_apply rules list so we can check if it's valid
         Config.auto_apply
@@ -121,7 +121,7 @@ module Hunter
 
         @buffer.nodes.each do |node|
           if node.label.nil?
-            label = node.auto_label(used_names: used_auto_strings, default_prefix: @options.prefix, default_start: @options.start, default_hostnames: @default_hostnames)
+            label = node.auto_label(used_names: used_auto_strings, default_prefix: @options.prefix, default_start: @options.start, default_label: @default_label)
 
             used_auto_strings << label
             new_labels << label
@@ -132,7 +132,7 @@ module Hunter
 
         all_labels = new_labels + @used_strings
         duplicate = all_labels.detect{ |name| all_labels.count(name) > 1 }
-        raise "One or more nodes generated a blank label, likely because '--default-hostnames' was set to 'blank'." if all_labels.include? ""
+        raise "One or more nodes generated a blank label, likely because '--default-label' was set to 'blank'." if all_labels.include? ""
         raise "The label #{duplicate} was parsed for multiple nodes. Resolve duplicates or try using '--skip-used-index'" if duplicate
 
         @buffer.nodes
@@ -206,7 +206,7 @@ module Hunter
             node.preset_label || node.auto_label(used_names: @used_strings + reserved,
                                                  default_prefix: @options.prefix,
                                                  default_start: @options.start,
-                                                 default_hostnames: @default_hostnames
+                                                 default_label: @default_label
                                                 )
           end
 

--- a/lib/hunter/config.rb
+++ b/lib/hunter/config.rb
@@ -85,8 +85,8 @@ module Hunter
         ENV['flight_HUNTER_auto_parse'] || data.fetch(:auto_parse)
       end
 
-      def default_hostnames
-        ENV['flight_HUNTER_default_hostnames'] || data.fetch(:default_hostnames) || "long"
+      def default_label
+        ENV['flight_HUNTER_default_label'] || data.fetch(:default_label) || "long"
       end
 
       def default_start

--- a/lib/hunter/node.rb
+++ b/lib/hunter/node.rb
@@ -86,9 +86,9 @@ module Hunter
       @label || @presets["label"]
     end
 
-    def auto_label(used_names: NodeList.load(Config.node_list).nodes.map(&:label), default_prefix: nil, default_start: nil, default_hostnames: "long")
+    def auto_label(used_names: NodeList.load(Config.node_list).nodes.map(&:label), default_prefix: nil, default_start: nil, default_label: Config.default_label)
       prefix = @presets["prefix"] || default_prefix
-      hostname = case default_hostnames
+      hostname = case default_label
                  when "long"
                    @hostname
                  when "short"


### PR DESCRIPTION
This PR fixes a bad interaction between `parse --auto` and the new `--default-hostnames` option. Previously, it was ignored entirely for automatic parsing. With the changes in this PR, it will be considered for both manual and automatic parsing modes. In the event that `parse --auto` is used and `default_hostnames` is set to `blank` (either in the command or in config), then the nodes will not be parsed if any of them generate blank names in this manner.