### PR TITLE
Unify node input approach

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@
 source 'https://rubygems.org'
 
 gem 'commander-openflighthpc', '~> 2.2.0'
+gem 'rubocop', group: 'development', require: false
 gem 'tty-prompt'
 gem 'tty-table'
 gem 'tty-config'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.2)
     bcrypt_pbkdf (1.1.0)
     commander-openflighthpc (2.2.0)
       highline (> 1.7.2)
@@ -26,11 +27,33 @@ GEM
     e2mmap (0.1.0)
     ed25519 (1.3.0)
     highline (2.0.3)
+    json (2.7.1)
     net-ssh (6.1.0)
     paint (2.1.1)
+    parallel (1.24.0)
+    parser (3.3.0.2)
+      ast (~> 2.4.1)
+      racc
     pastel (0.8.0)
       tty-color (~> 0.5)
     pidfile (0.3.0)
+    racc (1.7.3)
+    rainbow (3.1.1)
+    regexp_parser (2.9.0)
+    rexml (3.2.6)
+    rubocop (1.42.0)
+      json (~> 2.3)
+      parallel (~> 1.10)
+      parser (>= 3.1.2.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.24.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
     slop (4.9.2)
     strings (0.2.1)
       strings-ansi (~> 0.2)
@@ -65,6 +88,7 @@ DEPENDENCIES
   commander-openflighthpc (~> 2.2.0)
   flight-subprocess!
   pidfile
+  rubocop
   thwait
   tty-config
   tty-prompt

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ node0[1-5],login[1-2]
 will internally expand to:
 
 ```
-`node01, node02, node03, node04, node04, login1, login2
+node01, node02, node03, node04, node04, login1, login2
 ```
 
 You may instead use a comma separated list of regular expressions at the CLI, by including the `--regex` option. In this case, _any_ nodes matching _any_ of the expressions will be accessed.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Each of the above config keys can be overwritten at all levels by an environment
 
 Flight Hunter uses a PID file to track the `hunt` server process. By default, this PID file is created at `/tmp/hunter.pid`. The filepath used can be changed by setting the environment varaible `flight_HUNTER_pidfile`.
 
+
 ## Operation
 
 A brief usage guide is given below. See the `help` command for further details and information about other commands.
@@ -80,6 +81,24 @@ Add/remove groups to/from a node from the node list with `modify-groups`.
 Update the label of a node in the processed list with `modify-label`.
 
 Rename a group across a list with `rename-group`. All nodes with that group will be updated.
+
+### Node entry methods
+
+The `remove-node` and `modify-groups` commands accept a comma separated collection of either node search terms or regular expressions to match nodes against. When modifying buffer list nodes with the `--buffer` option, the terms are matched against the nodes' IDs; when modifying parsed nodes, they are matched against node labels.
+When using regular search terms, a comma separated list of terms is accepted. Each term can use genders-style square bracket syntax. Using a range of numbers in these brackets will search for anything in that range. For example:
+```
+node0[1-5],login[1-2]
+```
+
+will internally expand to:
+
+```
+`node01, node02, node03, node04, node04, login1, login2
+```
+
+You may instead use a comma separated list of regular expressions at the CLI, by including the `--regex` option. In this case, _any_ nodes matching _any_ of the expressions will be accessed.
+Please note that square bracket expansion is not supported for the regular expression input approach.
+
 
 ### Parsing nodes
 

--- a/lib/hunter/commands/concerns/node_utils.rb
+++ b/lib/hunter/commands/concerns/node_utils.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Hunter
+  module Commands
+    module NodeUtils
+      class InvalidRangeError < StandardError; end
+
+      def read_nodes(str)
+        statements = str.split(',')
+
+        collections = statements.map do |statement|
+          # Expand bracket format
+          expand_brackets(statement)
+        end
+
+        collections.reduce(:+).uniq
+      end
+
+      def expand_brackets(str)
+        contents = str[/\[.*\]/]
+
+        return [str] if contents.nil?
+
+        left = str[/[^\[]*/]
+        right = str[/].*/][1..-1]
+
+        unless contents.match(/^\[[0-9]+-[0-9]+\]$/)
+          raise InvalidRangeError, "'#{contents}' is not of the format [START-END]."
+        end
+
+        nums = contents[1..-2].split('-')
+
+        unless nums.first.to_i <  nums.last.to_i
+          raise InvalidRangeError, "'#{contents}' has a start index that is greater than its end index."
+        end
+
+        (nums.first..nums.last).map do |index|
+          left + index + right
+        end
+      end
+    end
+  end
+end

--- a/lib/hunter/commands/concerns/node_utils.rb
+++ b/lib/hunter/commands/concerns/node_utils.rb
@@ -55,7 +55,8 @@ module Hunter
           end
         end
 
-        attr_reader :list, :search_field
+        attr_reader :list
+        attr_accessor :search_field
 
         def scan(arr)
           arr.map { |n| @list.find(@search_field => n) }.compact

--- a/lib/hunter/commands/concerns/node_utils.rb
+++ b/lib/hunter/commands/concerns/node_utils.rb
@@ -5,6 +5,26 @@ require_relative '../../node_list'
 module Hunter
   module Commands
     module NodeUtils
+      private
+
+      def nodes_from_arg(arg)
+        # Don't try and expand the brackets in a regular expression
+        patterns = @options.regex ? arg.split(',') : cli_parser.expand(arg)
+        node_fetcher.scan(patterns, regex: @options.regex)
+      end
+
+      def cli_parser
+        @cli_parser ||= CLIParser.new
+      end
+
+      def node_fetcher
+        @node_fetcher ||= NodeFetcher.new(buffer: @options.buffer)
+      end
+
+      def list
+        node_fetcher.list
+      end
+
       class InvalidRangeError < StandardError; end
 
       class CLIParser

--- a/lib/hunter/commands/concerns/node_utils.rb
+++ b/lib/hunter/commands/concerns/node_utils.rb
@@ -58,8 +58,16 @@ module Hunter
         attr_reader :list
         attr_accessor :search_field
 
-        def scan(arr)
-          arr.map { |n| @list.find(@search_field => n) }.compact
+        def scan(arr, regex: false)
+          case regex
+          when true
+            results = arr.map do |r|
+              @list.select { |n| Regexp.new(r) =~ n.public_send(@search_field) }
+            end
+            results.reduce(:+).uniq.compact
+          else
+            arr.map { |n| @list.find(@search_field => n) }.compact
+          end
         end
       end
     end

--- a/lib/hunter/commands/concerns/node_utils.rb
+++ b/lib/hunter/commands/concerns/node_utils.rb
@@ -1,41 +1,64 @@
 # frozen_string_literal: true
 
+require_relative '../../node_list'
+
 module Hunter
   module Commands
     module NodeUtils
       class InvalidRangeError < StandardError; end
 
-      def read_nodes(str)
-        statements = str.split(',')
+      class CLIParser
+        def expand(str)
+          statements = str.split(',')
 
-        collections = statements.map do |statement|
-          # Expand bracket format
-          expand_brackets(statement)
+          collections = statements.map do |statement|
+            # Expand bracket format
+            expand_brackets(statement)
+          end
+
+          collections.reduce(:+).uniq.compact
         end
 
-        collections.reduce(:+).uniq
+        def expand_brackets(str)
+          contents = str[/\[.*\]/]
+
+          return [str] if contents.nil?
+
+          left = str[/[^\[]*/]
+          right = str[/].*/][1..-1]
+
+          unless contents.match(/^\[[0-9]+-[0-9]+\]$/)
+            raise InvalidRangeError, "'#{contents}' is not of the format [START-END]."
+          end
+
+          nums = contents[1..-2].split('-')
+
+          unless nums.first.to_i <  nums.last.to_i
+            raise InvalidRangeError, "'#{contents}' has a start index that is greater than its end index."
+          end
+
+          (nums.first..nums.last).map do |index|
+            left + index + right
+          end
+        end
       end
 
-      def expand_brackets(str)
-        contents = str[/\[.*\]/]
-
-        return [str] if contents.nil?
-
-        left = str[/[^\[]*/]
-        right = str[/].*/][1..-1]
-
-        unless contents.match(/^\[[0-9]+-[0-9]+\]$/)
-          raise InvalidRangeError, "'#{contents}' is not of the format [START-END]."
+      class NodeFetcher
+        def initialize(buffer: false)
+          case buffer
+          when true
+            @list = NodeList.load(Config.node_buffer)
+            @search_field = :id
+          else
+            @list = NodeList.load(Config.node_list)
+            @search_field = :label
+          end
         end
 
-        nums = contents[1..-2].split('-')
+        attr_reader :list, :search_field
 
-        unless nums.first.to_i <  nums.last.to_i
-          raise InvalidRangeError, "'#{contents}' has a start index that is greater than its end index."
-        end
-
-        (nums.first..nums.last).map do |index|
-          left + index + right
+        def scan(arr)
+          arr.map { |n| @list.find(@search_field => n) }.compact
         end
       end
     end

--- a/lib/hunter/commands/modify_groups.rb
+++ b/lib/hunter/commands/modify_groups.rb
@@ -34,8 +34,7 @@ module Hunter
       include NodeUtils
 
       def run
-        names = cli_parser.expand(args[0])
-        nodes = node_fetcher.scan(names)
+        nodes = nodes_from_arg(args[0])
 
         to_add = @options.add&.split(",") || []
         to_remove = @options.remove&.split(",") || []
@@ -52,20 +51,6 @@ module Hunter
         puts "Node(s) updated successfully:"
 
         Table.from_nodes(nodes, buffer: @options.buffer).emit
-      end
-
-      private
-
-      def cli_parser
-        @cli_parser ||= CLIParser.new
-      end
-
-      def node_fetcher
-        @node_fetcher ||= NodeFetcher.new(buffer: @options.buffer)
-      end
-
-      def list
-        node_fetcher.list
       end
     end
   end

--- a/lib/hunter/commands/modify_groups.rb
+++ b/lib/hunter/commands/modify_groups.rb
@@ -26,27 +26,21 @@
 #==============================================================================
 require_relative '../command'
 require_relative '../table'
+require_relative './concerns/node_utils'
 
 module Hunter
   module Commands
     class ModifyGroups < Command
+      include NodeUtils
+
       def run
-        buffer = @options.buffer
-        list_file = buffer ? Config.node_buffer : Config.node_list
-        list = NodeList.load(list_file)
+        names = cli_parser.expand(args[0])
+        nodes = node_fetcher.scan(names)
 
         to_add = @options.add&.split(",") || []
         to_remove = @options.remove&.split(",") || []
 
-        nodes = 
-          case @options.regex
-          when true
-            list.match(Regexp.new(args[0]))
-          when false
-            [list.find(search_field(buffer) => args[0])]
-          end
-        
-        raise "No #{search_field(buffer)}s in list '#{list.name}' match pattern '#{args[0]}'" unless nodes.any?
+        raise "No #{node_fetcher.search_field}s in list '#{list.name}' found in collection '#{args[0]}'" unless nodes.any?
 
         nodes.each do |n|
           n.add_groups(to_add)
@@ -56,8 +50,22 @@ module Hunter
         list.save
 
         puts "Node(s) updated successfully:"
-        
-        Table.from_nodes(nodes, buffer: buffer).emit
+
+        Table.from_nodes(nodes, buffer: @options.buffer).emit
+      end
+
+      private
+
+      def cli_parser
+        @cli_parser ||= CLIParser.new
+      end
+
+      def node_fetcher
+        @node_fetcher ||= NodeFetcher.new(buffer: @options.buffer)
+      end
+
+      def list
+        node_fetcher.list
       end
     end
   end

--- a/lib/hunter/commands/remove_node.rb
+++ b/lib/hunter/commands/remove_node.rb
@@ -33,9 +33,7 @@ module Hunter
       include NodeUtils
 
       def run
-        names = cli_parser.expand(args[0])
-        node_fetcher.search_field = :hostname if @options.match_hostname
-        nodes = node_fetcher.scan(names)
+        nodes = nodes_from_arg(args[0])
 
         raise "No #{node_fetcher.search_field}s in list '#{list.name}' found in collection '#{args[0]}'" unless nodes.any?
 
@@ -44,18 +42,6 @@ module Hunter
 
           Table.from_nodes(nodes, buffer: @options.buffer).emit
         end
-      end
-
-      def cli_parser
-        @cli_parser ||= CLIParser.new
-      end
-
-      def node_fetcher
-        @node_fetcher ||= NodeFetcher.new(buffer: @options.buffer)
-      end
-
-      def list
-        node_fetcher.list
       end
     end
   end

--- a/lib/hunter/commands/show.rb
+++ b/lib/hunter/commands/show.rb
@@ -34,7 +34,7 @@ module Hunter
       include NodeUtils
 
       def run
-        node = node_fetcher.scan([args[0]]).first
+        node = nodes_from_arg(args[0]).first
 
         raise "No #{node_fetcher.search_field} '#{args[0]}' found in list '#{list.name}'" unless node
 
@@ -51,20 +51,6 @@ module Hunter
           Table.from_nodes([node], buffer: @options.buffer).emit
           puts node.content
         end
-      end
-
-      private
-
-      def cli_parser
-        @cli_parser ||= CLIParser.new
-      end
-
-      def node_fetcher
-        @node_fetcher ||= NodeFetcher.new(buffer: @options.buffer)
-      end
-
-      def list
-        node_fetcher.list
       end
     end
   end

--- a/lib/hunter/node_list.rb
+++ b/lib/hunter/node_list.rb
@@ -60,10 +60,6 @@ module Hunter
       nodes.select(*args, **kwargs, &block)
     end
 
-    def match(regex)
-      nodes.select { |n| regex.match(n.hostname) }
-    end
-
     def to_yaml
       YAML.dump(nodes.map(&:to_h))
     end
@@ -106,7 +102,7 @@ module Hunter
       @dir = dir
       @nodes = Dir[File.join(dir, "*")].map do |file|
         data = YAML.load_file(file)
-        
+
         Node.new(
           id: data['id'],
           hostname: data['hostname'],


### PR DESCRIPTION
# Overview

This PR aims to create a single home for logic used to read nodes from the command line.

# Implementation

- The module `NodeUtils` holds methods/classes shared among commands that read nodes from the CLI.
- `CLIParser` accepts the raw CLI input, splits it into an array, and evaluates any square bracket expansion that may exist.
  - Regular expressions don't evaluate square brackets, but they're regular expressions so the user can handle that themselves.
- `NodeFetcher` takes an array of search tasks and a list, and fetches every node in that list that matches any of the given search tasks

# User experience

Each of the `remove-node` and `modify-groups` commands are using the new logic

- They each accept a comma-separated-collection (CSC) of either exact node names, node names with genders-style bracket expansion, or regular expressions
- Every node that matches the given collection definition will be modified by the command
- The `--regex` option specifies that the given CSC contains regular expressions
- The `--buffer` option specifies that the `buffer` node list should be used, matching against IDs instead of list labels

The `show` command also uses the new logic, but it remains limited to a single node name (and, therefore, doesn't support regular expressions).